### PR TITLE
Feat: 마이페이지 알림 설정 관련 api 구현

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
@@ -1,5 +1,7 @@
 package UMC.news.newsIntelligent.domain.dailyReport;
 
+import java.time.LocalTime;
+
 import UMC.news.newsIntelligent.domain.member.entity.Member;
 import UMC.news.newsIntelligent.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -32,5 +34,5 @@ public class DailyReport extends BaseEntity {
 	private Member member;
 
 	@Column(nullable = false)
-	private String reportTime;
+	private LocalTime reportTime;
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
@@ -35,4 +35,11 @@ public class DailyReport extends BaseEntity {
 
 	@Column(nullable = false)
 	private LocalTime reportTime;
+
+	public static DailyReport of(Member member, LocalTime reportTime) {
+		return DailyReport.builder()
+			.member(member)
+			.reportTime(reportTime)
+			.build();
+	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReport.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class DailyReport extends BaseEntity {
 
 	@Id

--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/repository/DailyReportRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/repository/DailyReportRepository.java
@@ -1,0 +1,11 @@
+package UMC.news.newsIntelligent.domain.dailyReport.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import UMC.news.newsIntelligent.domain.dailyReport.DailyReport;
+
+public interface DailyReportRepository extends JpaRepository<DailyReport, Long> {
+	List<DailyReport> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
@@ -1,12 +1,19 @@
 package UMC.news.newsIntelligent.domain.member.controller;
 
+import java.time.LocalTime;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import UMC.news.newsIntelligent.domain.dailyReport.repository.DailyReportRepository;
 import UMC.news.newsIntelligent.domain.member.dto.MemberSettingRequest;
 import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
 import UMC.news.newsIntelligent.domain.member.service.MemberSettingServiceImpl;
@@ -15,15 +22,17 @@ import UMC.news.newsIntelligent.global.apiPayload.code.success.GeneralSuccessCod
 import UMC.news.newsIntelligent.global.config.security.PrincipalUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/members/setting")
 @RequiredArgsConstructor
-@Tag(name = "마이페이지 알림 설정 API", description = "구독 토픽 알림, 읽은 토픽 알림, 데일리리포트 설정에 대한 api 입니다.")
+@Tag(name = "마이페이지 알림 설정 관련 API", description = "알림 설정과 설정 상태 조회")
 public class MemberSettingController {
 
 	private final MemberSettingServiceImpl settingService;
+	private final DailyReportRepository dailyReportRepository;
 
 	@Operation(summary = "구독 토픽 변경사항 알림 설정(on/off)",
 		description = "<p>구독한 토픽의 업데이트 알림을 토글 형식으로 설정합니다.")
@@ -65,5 +74,29 @@ public class MemberSettingController {
 	) {
 		MemberSettingResponse response = settingService.getAllSettings(principal.getMemberId());
 		return CustomResponse.onSuccess(GeneralSuccessCode.OK, response);
+	}
+
+	@Operation(summary = "데일리 리포트 수신 시간 추가 api",
+		description = "<p>데일리 리포트 시간은 최대 3개까지 추가 가능합니다."
+			+ "<p>아무것도 추가하지 않고 리포트 발신을 키면, default로 11:00이 기본 설정됩니다.")
+	@PostMapping("/daily-report/time")
+	public CustomResponse<Void> addReportTime(
+		@AuthenticationPrincipal PrincipalUserDetails principal,
+		@Valid @RequestBody MemberSettingRequest.ReportTimeRequest request
+	) {
+		LocalTime time = request.toLocalTime();
+		settingService.addReportTime(principal.getMemberId(), time);
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
+	}
+
+	@Operation(summary = "데일리리포트 수신 시간 삭제", description = "timeId는 데일리리포트의 PK id를 의미합니다.")
+	@DeleteMapping("/time/{timeId}")
+	public CustomResponse<Void> removeReportTime(
+		@AuthenticationPrincipal UserDetails user,
+		@PathVariable Long timeId
+	) {
+		Long memberId = Long.parseLong(user.getUsername());
+		settingService.removeReportTime(memberId, timeId);
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
 	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
@@ -1,0 +1,58 @@
+package UMC.news.newsIntelligent.domain.member.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import UMC.news.newsIntelligent.domain.member.dto.MemberSettingRequest;
+import UMC.news.newsIntelligent.domain.member.service.MemberSettingServiceImpl;
+import UMC.news.newsIntelligent.global.apiPayload.CustomResponse;
+import UMC.news.newsIntelligent.global.apiPayload.code.success.GeneralSuccessCode;
+import UMC.news.newsIntelligent.global.config.security.PrincipalUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/members/setting")
+@RequiredArgsConstructor
+@Tag(name = "마이페이지 알림 설정 API", description = "구독 토픽 알림, 읽은 토픽 알림, 데일리리포트 설정에 대한 api 입니다.")
+public class MemberSettingController {
+
+	private final MemberSettingServiceImpl settingService;
+
+	@Operation(summary = "구독 토픽 변경사항 알림 설정(on/off)",
+		description = "<p>구독한 토픽의 업데이트 알림을 토글 형식으로 설정합니다.")
+	@PatchMapping("/subscribe-notification")
+	public CustomResponse<Void> setSubscribeNotification(
+		@AuthenticationPrincipal PrincipalUserDetails principal,
+		@RequestBody MemberSettingRequest.ToggleRequest request
+	) {
+		settingService.setSubscribeNotification(principal.getMemberId(), request.getEnabled());
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
+	}
+
+	@Operation(summary = "읽은 토픽 변경사항 알림 설정(on/off)",
+		description = "<p>읽은 토픽 변경사항 알림을 토글 형식으로 설정합니다.")
+	@PatchMapping("/read-topic-notification")
+	public CustomResponse<Void> setReadTopicNotification(
+		@AuthenticationPrincipal PrincipalUserDetails principal,
+		@RequestBody MemberSettingRequest.ToggleRequest request
+	) {
+		settingService.setReadTopicNotification(principal.getMemberId(), request.getEnabled());
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
+	}
+
+	@Operation(summary = "데일리 리포트 발신 여부 설정(on/off)",
+		description = "<p>데일리 리포트를 수신 받을지, 안받을지를 토글 형식으로 설정합니다.")
+	@PatchMapping("/daily-report")
+	public CustomResponse<Void> setDailyReportSend(
+		@AuthenticationPrincipal PrincipalUserDetails principal,
+		@RequestBody MemberSettingRequest.ToggleRequest request
+	) {
+		settingService.setDailyReportSend(principal.getMemberId(), request.getEnabled());
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
+	}
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/MemberSettingController.java
@@ -1,12 +1,14 @@
 package UMC.news.newsIntelligent.domain.member.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import UMC.news.newsIntelligent.domain.member.dto.MemberSettingRequest;
+import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
 import UMC.news.newsIntelligent.domain.member.service.MemberSettingServiceImpl;
 import UMC.news.newsIntelligent.global.apiPayload.CustomResponse;
 import UMC.news.newsIntelligent.global.apiPayload.code.success.GeneralSuccessCode;
@@ -54,5 +56,14 @@ public class MemberSettingController {
 	) {
 		settingService.setDailyReportSend(principal.getMemberId(), request.getEnabled());
 		return CustomResponse.onSuccess(GeneralSuccessCode.OK, null);
+	}
+
+	@Operation(summary = "전체 알림 설정 상태 조회 api", description = "마이페이지 내의 전체 알림 설정 상태를 조회합니다.")
+	@GetMapping
+	public CustomResponse<MemberSettingResponse> getMemberSetting(
+		@AuthenticationPrincipal PrincipalUserDetails principal
+	) {
+		MemberSettingResponse response = settingService.getAllSettings(principal.getMemberId());
+		return CustomResponse.onSuccess(GeneralSuccessCode.OK, response);
 	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingRequest.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingRequest.java
@@ -1,0 +1,15 @@
+package UMC.news.newsIntelligent.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberSettingRequest {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class ToggleRequest {
+		private Boolean enabled;
+	}
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingRequest.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingRequest.java
@@ -1,5 +1,9 @@
 package UMC.news.newsIntelligent.domain.member.dto;
 
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +15,25 @@ public class MemberSettingRequest {
 	@AllArgsConstructor
 	public static class ToggleRequest {
 		private Boolean enabled;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class ReportTimeRequest {
+
+		/**
+		 * "HH:mm" (00:00~23:59)
+		 */
+		@NotBlank
+		@Pattern(
+			regexp = "^([01]\\d|2[0-3]):[0-5]\\d$",
+			message = "HH:mm 형식이어야 합니다"
+		)
+		private String time;
+
+		public LocalTime toLocalTime() {
+			return LocalTime.parse(this.time);
+		}
 	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
@@ -1,0 +1,16 @@
+package UMC.news.newsIntelligent.domain.member.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSettingResponse {
+
+	private Boolean subscribeNotification;
+	private Boolean readTopicNotification;
+	private Boolean dailyReportSend;
+	private List<String> dailyReportTimes;  // "HH:mm" 문자열 목록
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.member.dto;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -12,5 +13,5 @@ public class MemberSettingResponse {
 	private Boolean subscribeNotification;
 	private Boolean readTopicNotification;
 	private Boolean dailyReportSend;
-	private List<String> dailyReportTimes;  // "HH:mm" 문자열 목록
+	private List<LocalTime> dailyReportTimes;  // "HH:mm" 문자열 목록
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberSettingResponse.java
@@ -13,5 +13,5 @@ public class MemberSettingResponse {
 	private Boolean subscribeNotification;
 	private Boolean readTopicNotification;
 	private Boolean dailyReportSend;
-	private List<LocalTime> dailyReportTimes;  // "HH:mm" 문자열 목록
+	private List<LocalTime> dailyReportTimes;
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/entity/Member.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/entity/Member.java
@@ -55,12 +55,14 @@ public class Member extends BaseEntity {
 		cascade = CascadeType.ALL,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
+	@Builder.Default
 	private List<DailyReport> dailyReports = new ArrayList<>();
 
 	@OneToMany(
 		mappedBy = "member",
 		cascade = CascadeType.ALL,
 		orphanRemoval = true)
+	@Builder.Default
 	private List<MemberTopic> memberTopics = new ArrayList<>();
 
 	public static Member newMember(String email) {

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/entity/Member.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/entity/Member.java
@@ -83,4 +83,13 @@ public class Member extends BaseEntity {
 	public boolean isDeactivated() {
 		return Boolean.TRUE.equals(isDeactivated);
 	}
+	public void setSubscribeTopicAlert(Boolean subscribeTopicAlert) {
+		this.subscribeTopicAlert = subscribeTopicAlert;
+	}
+	public void setReadTopicAlert(Boolean readTopicAlert) {
+		this.readTopicAlert = readTopicAlert;
+	}
+	public void setDailyReportAlert(Boolean dailyReportAlert) {
+		this.dailyReportAlert = dailyReportAlert;
+	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
@@ -1,0 +1,7 @@
+package UMC.news.newsIntelligent.domain.member.service;
+
+public interface MemberSettingService {
+	void setSubscribeNotification(Long memberId, Boolean enabled);
+	void setReadTopicNotification(Long memberId, Boolean enabled);
+	void setDailyReportSend(Long memberId, Boolean enabled);
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
@@ -1,7 +1,10 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
+import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
+
 public interface MemberSettingService {
 	void setSubscribeNotification(Long memberId, Boolean enabled);
 	void setReadTopicNotification(Long memberId, Boolean enabled);
 	void setDailyReportSend(Long memberId, Boolean enabled);
+	MemberSettingResponse getAllSettings(Long memberId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingService.java
@@ -1,5 +1,7 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
+import java.time.LocalTime;
+
 import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
 
 public interface MemberSettingService {
@@ -7,4 +9,6 @@ public interface MemberSettingService {
 	void setReadTopicNotification(Long memberId, Boolean enabled);
 	void setDailyReportSend(Long memberId, Boolean enabled);
 	MemberSettingResponse getAllSettings(Long memberId);
+	void addReportTime(Long memberId, LocalTime time);
+	void removeReportTime(Long memberId, Long timeId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
@@ -1,8 +1,12 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import UMC.news.newsIntelligent.domain.dailyReport.DailyReport;
+import UMC.news.newsIntelligent.domain.dailyReport.repository.DailyReportRepository;
 import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
 import UMC.news.newsIntelligent.domain.member.entity.Member;
 import UMC.news.newsIntelligent.domain.member.repository.MemberRepository;
@@ -16,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberSettingServiceImpl implements MemberSettingService {
 
 	private final MemberRepository memberRepository;
+	private final DailyReportRepository dailyReportRepository;
 
 	private Member findMember(Long memberId) {
 		return memberRepository.findById(memberId)
@@ -38,5 +43,22 @@ public class MemberSettingServiceImpl implements MemberSettingService {
 	public void setDailyReportSend(Long memberId, Boolean enabled) {
 		Member m = findMember(memberId);
 		m.setDailyReportAlert(enabled);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public MemberSettingResponse getAllSettings(Long memberId) {
+		Member m = findMember(memberId);
+
+		List<String> reportTimes = dailyReportRepository.findAllByMemberId(memberId).stream()
+			.map(DailyReport::getReportTime)
+			.toList();
+
+		return new MemberSettingResponse(
+			m.getSubscribeTopicAlert(),
+			m.getReadTopicAlert(),
+			m.getDailyReportAlert(),
+			reportTimes
+		);
 	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
@@ -62,4 +62,33 @@ public class MemberSettingServiceImpl implements MemberSettingService {
 			reportTimes
 		);
 	}
+
+	@Override
+	public void addReportTime(Long memberId, LocalTime reportTime) {
+		Member m = findMember(memberId);
+
+		List<DailyReport> existing = dailyReportRepository.findAllByMemberId(memberId);
+		// 시간 추가 최대 3개
+		if(existing.size() >= 3) {
+			throw new CustomException(GeneralErrorCode.VALIDATION_FAILED);
+		}
+		// 시간 중복 추가 방지 검증
+		boolean dup = existing.stream()
+			.anyMatch(dr -> dr.getReportTime().equals(reportTime));
+		if (dup) {
+			throw new CustomException(GeneralErrorCode.VALIDATION_FAILED);
+		}
+		DailyReport report = DailyReport.of(m, reportTime);
+		dailyReportRepository.save(report);
+	}
+
+	@Override
+	public void removeReportTime(Long memberId, Long timeId) {
+		DailyReport report = dailyReportRepository.findById(timeId)
+			.orElseThrow(() -> new CustomException(GeneralErrorCode.DAILY_REPORT_NOT_FOUND));
+		if (!report.getMember().getId().equals(memberId)) {
+			throw new CustomException(GeneralErrorCode.FORBIDDEN_403);
+		}
+		dailyReportRepository.delete(report);
+	}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
@@ -43,7 +43,13 @@ public class MemberSettingServiceImpl implements MemberSettingService {
 	@Override
 	public void setDailyReportSend(Long memberId, Boolean enabled) {
 		Member m = findMember(memberId);
+
+		if (enabled && m.getDailyReports().isEmpty()) {
+			addReportTime(memberId, LocalTime.of(11, 0));
+		}
+
 		m.setDailyReportAlert(enabled);
+		memberRepository.save(m);
 	}
 
 	@Override

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -50,7 +51,7 @@ public class MemberSettingServiceImpl implements MemberSettingService {
 	public MemberSettingResponse getAllSettings(Long memberId) {
 		Member m = findMember(memberId);
 
-		List<String> reportTimes = dailyReportRepository.findAllByMemberId(memberId).stream()
+		List<LocalTime> reportTimes = dailyReportRepository.findAllByMemberId(memberId).stream()
 			.map(DailyReport::getReportTime)
 			.toList();
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberSettingServiceImpl.java
@@ -1,0 +1,42 @@
+package UMC.news.newsIntelligent.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import UMC.news.newsIntelligent.domain.member.dto.MemberSettingResponse;
+import UMC.news.newsIntelligent.domain.member.entity.Member;
+import UMC.news.newsIntelligent.domain.member.repository.MemberRepository;
+import UMC.news.newsIntelligent.global.apiPayload.code.error.GeneralErrorCode;
+import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberSettingServiceImpl implements MemberSettingService {
+
+	private final MemberRepository memberRepository;
+
+	private Member findMember(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new CustomException(GeneralErrorCode.NOT_FOUND_404));
+	}
+
+	@Override
+	public void setSubscribeNotification(Long memberId, Boolean enabled) {
+		Member m = findMember(memberId);
+		m.setSubscribeTopicAlert(enabled);
+	}
+
+	@Override
+	public void setReadTopicNotification(Long memberId, Boolean enabled) {
+		Member m = findMember(memberId);
+		m.setReadTopicAlert(enabled);
+	}
+
+	@Override
+	public void setDailyReportSend(Long memberId, Boolean enabled) {
+		Member m = findMember(memberId);
+		m.setDailyReportAlert(enabled);
+	}
+}

--- a/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/error/GeneralErrorCode.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/error/GeneralErrorCode.java
@@ -27,6 +27,8 @@ public enum GeneralErrorCode implements BaseErrorCode{
     // 토픽 관련 에러
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC400", "해당 토픽을 찾을 수 없습니다."),
     MEMBERTOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC401", "해당 멤버와 관계를 가진 토픽을 찾을 수 없습니다."),
+    // 데일리 리포트 관련 에러
+    DAILY_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT400", "데일리 리포트를 찾을 수 없습니다."),
 
     /* --- 회원/인증 관련 에러 ---*/
     OTP_WRONG      ( HttpStatus.BAD_REQUEST, "AUTH401", "인증번호가 일치하지 않습니다."),


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #45 

## ✅ PR 전 확인!
- [ ] 변경 사항에 대한 테스트 완료
- [ ] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용

<!-- 무엇을 왜 수정했는지 설명하면 리뷰어에게 도움이 됩니다!-->
- 구독 알림 설정			PATCH	/api/members/setting/subscribe-notification
- 읽은 주제 변경사항 알림 설정	PATCH	/api/members/setting/read-topic-notification
- 데일리리포트 수신 설정		PATCH	/api/members/setting/daily-report
- 데일리리포트 시간 추가		POST	/api/members/setting/daily-report/time
- 데일리리포트 시간 삭제		DELETE	/api/members/setting/daily-report/time/{timeId}
- 알림 설정 상태 전체 조회	GET		/api/members/setting


## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
