### PR TITLE
Fix: PrincipalUserDetails 오류 수정

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/global/config/security/PrincipalUserDetails.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/config/security/PrincipalUserDetails.java
@@ -14,10 +14,11 @@ public class PrincipalUserDetails implements UserDetails {
 
     private final Long memberId;
     private final String email;
+    private final Collection<? extends GrantedAuthority> authorities;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(() -> "ROLE_USER");
+        return authorities;
     }
 
     // 비밀번호 인증 사용 X

--- a/src/main/java/UMC/news/newsIntelligent/global/config/security/SecurityConfig.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/config/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(
                         (requests) -> requests
-                                .requestMatchers("/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .requestMatchers(
                                         "/api/members/signup/**",
                                         "/api/members/login/**"
@@ -62,10 +62,9 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOrigins(List.of(
-                "http://localhost:5173",    // 로컬 개발 환경
+                "http://localhost:5173",
                 "https://newsintelligent.site",
                 "https://www.newsintelligent.site",
-                "https://api.newsintelligent.site",
                 "https://api.newsintelligent.site"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/UMC/news/newsIntelligent/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/config/security/jwt/JwtTokenProvider.java
@@ -66,16 +66,16 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
 
-        Long id = ((Number) claims.get("id")).longValue();
+        Long memberId = claims.get("id", Long.class);
         String email = claims.getSubject();
         String role  = claims.get("role", String.class);
         if (role == null) role = "ROLE_USER";
 
-        // 권한은 SimpleGrantedAuthority로 명시
-        var authorities = List.of(new SimpleGrantedAuthority(role));
-        var principal = new User(email, "", authorities);
+        // principal user details로 변경
+        PrincipalUserDetails principal =
+                new PrincipalUserDetails(memberId, email, List.of(new SimpleGrantedAuthority(role)));
 
-        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }
 
     public static String resolveToken(HttpServletRequest request) {


### PR DESCRIPTION
## Issue 번호

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- 인증된 사용자인데도 principal이 계속 null 로 들어오는 오류 수정
    -> 원인 : SecurityContext에 실제 Authentication 객체가 들어오지 않아서 발생

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
