### PR TITLE
Refactor: 이메일 템플릿 적용

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/mail/EmailHtmlTemplate.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/mail/EmailHtmlTemplate.java
@@ -1,0 +1,126 @@
+package UMC.news.newsIntelligent.domain.mail;
+
+public final class EmailHtmlTemplate {
+
+    private EmailHtmlTemplate() {}
+
+    // 공통 이메일 html 템플릿
+    private static final String BASE = """
+        <!DOCTYPE html>
+        <html lang="ko">
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>%s</title>
+          <style>
+            body {
+              font-family: 'Pretendard', sans-serif;
+              background-color: #f5f5f5;
+              margin: 0;
+              padding: 0;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              height: 100vh;
+            }
+            .container {
+              background: #fff;
+              padding: 32px;
+              width: 400px;
+              border-radius: 8px;
+              box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+            }
+            .logo {
+              color: #174347;
+              font-size: 24px;
+              font-weight: bold;
+              margin-bottom: 24px;
+            }
+            .title {
+              font-size: 20px;
+              font-weight: 700;
+              margin-bottom: 8px;
+            }
+            .desc {
+              font-size: 14px;
+              color: #333;
+              line-height: 1.5;
+              margin-bottom: 24px;
+            }
+            .code-box {
+              background: #f4f4f4;
+              padding: 24px;
+              text-align: center;
+              font-size: 32px;
+              font-weight: 600;
+              color: #555;
+              letter-spacing: 4px;
+              border-radius: 8px;
+              margin-bottom: 24px;
+            }
+            .login-btn {
+              display: block;
+              text-align: center;
+              background-color: #4da3b6;
+              color: white;
+              padding: 12px;
+              text-decoration: none;
+              border-radius: 6px;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 16px;
+            }
+            .login-btn:hover {
+              background-color: #3e92a1;
+            }
+            .footer {
+              font-size: 12px;
+              color: #666;
+              line-height: 1.4;
+            }
+          </style>
+        </head>
+        <body>
+          <div class="container">
+            <div class="logo">News Intelligent</div>
+            <div class="title">%s</div>
+            <div class="desc">%s</div>
+            <div class="code-box">%s</div>
+            <a class="login-btn" href="%s">%s</a>
+            <div class="footer">
+              이메일을 요청하지 않았다더라도 걱정하지 마세요.<br />
+              이메일을 무시하면 됩니다.
+            </div>
+          </div>
+        </body>
+        </html>
+        """;
+
+    private static String render(String pageTitle, String title, String desc, String codeText, String linkUrl, String buttonText) {
+        return BASE.formatted(pageTitle, title, desc, codeText, linkUrl, buttonText);
+    }
+
+    // 회원가입 & 로그인
+    public static String renderOtpVerify(String codeText, String linkUrl) {
+        return render(
+                "이메일 주소 확인",
+                "이메일 주소 확인",
+                "여기에 확인 코드가 있습니다. 열린 브라우저 창에 복사하거나 아래 링크를 클릭하여 이 이메일 주소를 확인할 수 있습니다.",
+                codeText,
+                linkUrl,
+                "확인 및 로그인"
+        );
+    }
+
+    // 알림 이메일 변경
+    public static String renderNotificationChange(String codeText, String linkUrl) {
+        return render(
+                "알림 이메일 변경 확인",
+                "알림 이메일 변경 확인",
+                "아래 확인 코드를 입력하시거나 버튼을 클릭해 알림 이메일 변경을 완료해 주세요.",
+                codeText,
+                linkUrl,
+                "이메일 변경 확인"
+        );
+    }
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/mail/EmailHtmlTemplate.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/mail/EmailHtmlTemplate.java
@@ -4,105 +4,73 @@ public final class EmailHtmlTemplate {
 
     private EmailHtmlTemplate() {}
 
-    // 공통 이메일 html 템플릿
-    private static final String BASE = """
+    private static String base(String pageTitle,
+                               String title,
+                               String desc,
+                               String codeText,
+                               String linkUrl,
+                               String buttonText) {
+        return """
         <!DOCTYPE html>
         <html lang="ko">
         <head>
-          <meta charset="UTF-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <meta charset="UTF-8">
           <title>%s</title>
-          <style>
-            body {
-              font-family: 'Pretendard', sans-serif;
-              background-color: #f5f5f5;
-              margin: 0;
-              padding: 0;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              height: 100vh;
-            }
-            .container {
-              background: #fff;
-              padding: 32px;
-              width: 400px;
-              border-radius: 8px;
-              box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-            }
-            .logo {
-              color: #174347;
-              font-size: 24px;
-              font-weight: bold;
-              margin-bottom: 24px;
-            }
-            .title {
-              font-size: 20px;
-              font-weight: 700;
-              margin-bottom: 8px;
-            }
-            .desc {
-              font-size: 14px;
-              color: #333;
-              line-height: 1.5;
-              margin-bottom: 24px;
-            }
-            .code-box {
-              background: #f4f4f4;
-              padding: 24px;
-              text-align: center;
-              font-size: 32px;
-              font-weight: 600;
-              color: #555;
-              letter-spacing: 4px;
-              border-radius: 8px;
-              margin-bottom: 24px;
-            }
-            .login-btn {
-              display: block;
-              text-align: center;
-              background-color: #4da3b6;
-              color: white;
-              padding: 12px;
-              text-decoration: none;
-              border-radius: 6px;
-              font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 16px;
-            }
-            .login-btn:hover {
-              background-color: #3e92a1;
-            }
-            .footer {
-              font-size: 12px;
-              color: #666;
-              line-height: 1.4;
-            }
-          </style>
         </head>
-        <body>
-          <div class="container">
-            <div class="logo">News Intelligent</div>
-            <div class="title">%s</div>
-            <div class="desc">%s</div>
-            <div class="code-box">%s</div>
-            <a class="login-btn" href="%s">%s</a>
-            <div class="footer">
-              이메일을 요청하지 않았다더라도 걱정하지 마세요.<br />
-              이메일을 무시하면 됩니다.
-            </div>
-          </div>
+        <body style="margin:0; padding:0; background-color:#f5f5f5;">
+          <table role="presentation" width="100%%" cellspacing="0" cellpadding="0" style="background-color:#f5f5f5;">
+            <tr>
+              <td align="center" style="padding:24px;">
+                <table role="presentation" width="400" cellspacing="0" cellpadding="0"
+                       style="background:#ffffff; border-radius:8px; font-family: Arial, Helvetica, sans-serif;">
+                  <tr>
+                    <td style="padding:24px 24px 8px 24px; color:#174347; font-size:24px; font-weight:bold;">
+                      News Intelligent
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 24px 8px 24px; font-size:20px; font-weight:700; color:#000;">
+                      %s
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 24px 24px 24px; font-size:14px; color:#333; line-height:1.5;">
+                      %s
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 24px 24px 24px;">
+                      <div style="background:#f4f4f4; padding:24px; text-align:center; font-size:32px; font-weight:600; color:#555; letter-spacing:4px; border-radius:8px;">
+                        %s
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 24px 16px 24px;">
+                      <a href="%s"
+                         style="display:block; text-align:center; background-color:#4da3b6; color:#ffffff; padding:12px; text-decoration:none; border-radius:6px; font-size:14px; font-weight:600;">
+                        %s
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 24px 24px 24px; font-size:12px; color:#666; line-height:1.4;">
+                      이메일을 요청하지 않았다더라도 걱정하지 마세요.<br>
+                      이메일을 무시하면 됩니다.
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
         </body>
         </html>
-        """;
-
-    private static String render(String pageTitle, String title, String desc, String codeText, String linkUrl, String buttonText) {
-        return BASE.formatted(pageTitle, title, desc, codeText, linkUrl, buttonText);
+        """.formatted(pageTitle, title, desc, codeText, linkUrl, buttonText);
     }
 
     // 회원가입 & 로그인
-    public static String renderOtpVerify(String codeText, String linkUrl) {
-        return render(
+    public static String renderOtp(String codeText, String linkUrl) {
+        return base(
                 "이메일 주소 확인",
                 "이메일 주소 확인",
                 "여기에 확인 코드가 있습니다. 열린 브라우저 창에 복사하거나 아래 링크를 클릭하여 이 이메일 주소를 확인할 수 있습니다.",
@@ -114,7 +82,7 @@ public final class EmailHtmlTemplate {
 
     // 알림 이메일 변경
     public static String renderNotificationChange(String codeText, String linkUrl) {
-        return render(
+        return base(
                 "알림 이메일 변경 확인",
                 "알림 이메일 변경 확인",
                 "아래 확인 코드를 입력하시거나 버튼을 클릭해 알림 이메일 변경을 완료해 주세요.",

--- a/src/main/java/UMC/news/newsIntelligent/domain/mail/service/MailService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/mail/service/MailService.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.mail.service;
 
+import UMC.news.newsIntelligent.domain.mail.EmailHtmlTemplate;
 import UMC.news.newsIntelligent.domain.mail.entity.OtpCode;
 import jakarta.mail.Message;
 import jakarta.mail.internet.InternetAddress;
@@ -20,8 +21,7 @@ public class MailService {
     private final JavaMailSender mailSender;
 
     @Value("${spring.mail.username}") private String from;
-    // 도메인 연결 후 추가
-    // @Value("${app.front-url}") private String frontUrl;
+    @Value("${server.host.front}") private String frontUrl;
 
     public String generateCode() {
         return String.format("%06d", new SecureRandom().nextInt(1_000_000));
@@ -29,53 +29,38 @@ public class MailService {
     public String generateToken() {
         return UUID.randomUUID().toString().replace("-", "");
     }
+    private String hyphenateCode(String code) {
+        return (code != null && code.length() == 6)
+                // 코드 표기: 하이픈 형태
+                ? code.substring(0, 3) + "-" + code.substring(3)
+                : code;
+    }
+    private String baseUrl() {
+        String b = frontUrl == null ? "" : frontUrl.trim();
+        return b.endsWith("/") ? b.substring(0, b.length() - 1) : b;
+    }
+
 
     public void sendOtpMail(String to, String code, String token, OtpCode.Type type) {
-        String path  = (type == OtpCode.Type.SIGNUP) ? "signup" : "login";
-        String link  = "https://newsintelligent.io/%s/magic?token=%s".formatted(path, token);
-
-        String html = """
-            <div style='margin:80px;font-family:Verdana'>
-                <section style="display: flex;">
-                    <h2 style='color:#07525F'>📨 NewsIntelligent</h2>
-                    &nbsp;&nbsp;
-                    <h2>인증 메일입니다.</h2>
-                </section>
-                <p>아래 <b>코드</b>를 입력하거나 <b>매직링크</b>를 클릭하세요.</p>
-                <h1 style='color:#07525F'>%s</h1>
-                <p><a href='%s' style="color: black;">➡️ 매직링크 바로가기</a> · 5분 내 1회 사용</p>
-            </div>
-            """.formatted(code, link);
-
-        try {
-            MimeMessage msg = mailSender.createMimeMessage();
-            msg.addRecipients(Message.RecipientType.TO, to);
-            msg.setSubject("[NewsIntelligent] 인증 메일");
-            msg.setText(html, "utf-8", "html");
-            msg.setFrom(new InternetAddress(from, "NewsIntelligent"));
-            mailSender.send(msg);
-        } catch (Exception e) {
-            throw new IllegalStateException("메일 발송 실패", e);
-        }
+        String path  = (type == OtpCode.Type.SIGNUP) ? "/signup/magic" : "/login/magic";
+        String link = baseUrl() + path + "?token=" + token;
+        String html = EmailHtmlTemplate.renderOtpVerify(hyphenateCode(code), link);
+        sendHtml(to, "[NewsIntelligent] 이메일 주소 확인", html);
     }
 
     public void sendNotificationEmailChangeMail(String to, String code, String token) {
-        String link  = "https://newsintelligent.io/settings/notification-email/magic?token=%s".formatted(token);
+        String link  = baseUrl() + "/settings/notification-email/magic?token=" + token;
+        String html = EmailHtmlTemplate.renderNotificationChange(hyphenateCode(code), link);
+        sendHtml(to, "[NewsIntelligent] 알림 이메일 변경 확인", html);
+    }
 
-        String html = """
-            <div style='margin:80px;font-family:Verdana'>
-              <h2>알림 이메일 변경 인증</h2>
-              <p>아래 <b>코드</b>를 입력하거나 <b>매직링크</b>를 클릭해 주세요.</p>
-              <h1 style='color:#07525F'>%s</h1>
-              <p><a href='%s' style="color: black;"> · 10분 내 1회 사용</p>
-            </div>
-            """.formatted(code, link);
-
+    // 공통 발송 로직
+    private void sendHtml(String to, String title, String html) {
         try {
             MimeMessage msg = mailSender.createMimeMessage();
             msg.addRecipients(Message.RecipientType.TO, to);
-            msg.setSubject("[NewsIntelligent] 알림 이메일 변경 인증");
-            msg.setText(html, "utf-8", "html");
+            msg.setSubject(title, "UTF-8");
+            msg.setText(html, "UTF-8", "html");
             msg.setFrom(new InternetAddress(from, "NewsIntelligent"));
             mailSender.send(msg);
         } catch (Exception e) {

--- a/src/main/java/UMC/news/newsIntelligent/domain/mail/service/MailService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/mail/service/MailService.java
@@ -44,7 +44,7 @@ public class MailService {
     public void sendOtpMail(String to, String code, String token, OtpCode.Type type) {
         String path  = (type == OtpCode.Type.SIGNUP) ? "/signup/magic" : "/login/magic";
         String link = baseUrl() + path + "?token=" + token;
-        String html = EmailHtmlTemplate.renderOtpVerify(hyphenateCode(code), link);
+        String html = EmailHtmlTemplate.renderOtp(hyphenateCode(code), link);
         sendHtml(to, "[NewsIntelligent] 이메일 주소 확인", html);
     }
 


### PR DESCRIPTION
## Issue 번호
- #58 

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- 피그마와 동일하게 이메일 본문 템플릿으로 적용하였습니다. css 미적용 이슈가 있어서 템플릿은 별도의 클래스로 분리하였습니다.
- 이메일 전송 로직에서 공통되는 로직을 메서드로 분리하였습니다.
- 매직링크 url 프론트와 동일하게 맞춰 수정하였습니다.

## 🖼️ 관련 스크린샷 (선택)
### 기존 (수정 전)
<img width="1470" height="730" alt="스크린샷 2025-08-08 19 54 39" src="https://github.com/user-attachments/assets/2b96af51-fe28-4978-9ec8-214d123bad2e" />

### 현재 (수정 후)
<img width="1470" height="724" alt="스크린샷 2025-08-08 19 51 43" src="https://github.com/user-attachments/assets/e2c236e5-0152-4a6b-93a2-77aa52b0112f" />


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
