### PR TITLE
Feat: 홈 메인화면(토픽 목록 조회) 구현

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/controller/TopicController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/controller/TopicController.java
@@ -35,7 +35,7 @@ public class TopicController {
     private final MemberTopicCommandService memberTopicCommandService;
 
     /* --- 토픽 조회 --- */
-    @Operation(summary = "토픽 조회", description = "토픽을 조회하는 API입니다.")
+    @Operation(summary = "토픽 검색 결과 조회", description = "토픽 검색 결과를 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토픽 조회 성공")
     })
@@ -46,6 +46,22 @@ public class TopicController {
             @RequestParam(defaultValue = "10") @Max(10) int size
     ) {
         TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.searchTopics(keyword, cursor, size);
+
+        return CustomResponse.onSuccess(topicResDTO);
+    }
+
+    @Operation(
+            summary = "토픽 목록(홈화면) 조회",
+            description = "<p>최신순으로 토픽 목록을 조회하는 API입니다."
+                    + "<p>응답의 마지막 아이템 id를 다음 요청의 cursor 값으로 전달하면 됩니다."
+                    + "<p>첫 페이지 조회 시에는 cursor를 비우거나 0으로 설정하세요."
+    )
+    @GetMapping("/home")
+    public CustomResponse<TopicResponseDTO.TopicPreviewListResDTO> getTopics(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") @Max(10) int size
+    ) {
+        TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.getTopicList(cursor, size);
 
         return CustomResponse.onSuccess(topicResDTO);
     }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/entity/Topic.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/entity/Topic.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Topic extends BaseEntity {
+public class Topic {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/repository/TopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/repository/TopicRepository.java
@@ -17,4 +17,19 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
         ORDER BY t.id DESC
     """)
     Slice<Topic> findByKeywordAndCursor(@Param("keyword") String keyword, @Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("""
+    SELECT t FROM Topic t
+    WHERE (
+        :cursorTime IS NULL
+        OR t.summaryTime < :cursorTime
+        OR (t.summaryTime = :cursorTime AND t.id < :cursorId)
+    )
+    ORDER BY t.summaryTime DESC, t.id DESC
+""")
+    Slice<Topic> findByCursorOrderBySummaryTimeDesc(
+            @Param("cursorTime") java.time.LocalDateTime cursorTime,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
@@ -6,5 +6,7 @@ import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 public interface TopicQueryService {
     TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size);
 
+    TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size);
+
     TopicResponseDTO.TopicDetailsResDTO getTopicById(Long topicId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -31,7 +31,19 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = topicRepository.findByKeywordAndCursor(keyword, cursor, pageable);
 
-        return getTopicPreviewListResDTO(topicSlice);
+        List<TopicResponseDTO.TopicPreviewResDTO> topicList = topicSlice.stream()
+                .map(TopicConverter::toPreviewResDTO)
+                .toList();
+
+        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
+                ? topicList.get(topicList.size() - 1).id()
+                : null;
+
+        return TopicResponseDTO.TopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(topicSlice.hasNext())
+                .topics(topicList)
+                .build();
     }
 
     private Long normalizeCursor(Long cursor) {
@@ -89,21 +101,5 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                 topic.getImageUrl(),
                 topic.getSummaryTime()
         );
-    }
-
-    private TopicResponseDTO.TopicPreviewListResDTO getTopicPreviewListResDTO(Slice<Topic> topicSlice) {
-        List<TopicResponseDTO.TopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(TopicConverter::toPreviewResDTO)
-                .toList();
-
-        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
-                ? topicList.get(topicList.size() - 1).id()
-                : null;
-
-        return TopicResponseDTO.TopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
-                .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -30,19 +31,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = topicRepository.findByKeywordAndCursor(keyword, cursor, pageable);
 
-        List<TopicResponseDTO.TopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(TopicConverter::toPreviewResDTO)
-                .toList();
-
-        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
-                ? topicList.get(topicList.size() - 1).id()
-                : null;
-
-        return TopicResponseDTO.TopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
-                .build();
+        return getTopicPreviewListResDTO(topicSlice);
     }
 
     private Long normalizeCursor(Long cursor) {
@@ -54,6 +43,39 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         return (size < 1 || size > 10) ? 10 : size;
     }
 
+    @Override
+    public TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size) {
+        size = normalizeSize(size);
+
+        Pageable pageable = PageRequest.of(0, size);
+
+        LocalDateTime cursorTime = null;
+        Long cursorId = null;
+
+        // 첫 페이지: cursor == null -> 최신부터
+        if (cursor != null && cursor != 0) {
+            Topic last = topicRepository.findById(cursor).orElse(null);
+            if (last != null) {
+                cursorTime = last.getSummaryTime();
+                cursorId   = last.getId();
+            } else {
+                throw new CustomException(ErrorCode.CURSOR_INVALID);
+            }
+        }
+
+        Slice<Topic> slice = topicRepository.findByCursorOrderBySummaryTimeDesc(cursorTime, cursorId, pageable);
+
+        // 커서는 마지막 아이템의 id
+        List<TopicResponseDTO.TopicPreviewResDTO> topics = slice.getContent()
+                .stream().map(TopicConverter::toPreviewResDTO).toList();
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty()) ? topics.get(topics.size()-1).id() : null;
+
+        return TopicResponseDTO.TopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(slice.hasNext())
+                .topics(topics)
+                .build();
+    }
 
     @Override
     public TopicResponseDTO.TopicDetailsResDTO getTopicById(Long topicId) {
@@ -67,5 +89,21 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                 topic.getImageUrl(),
                 topic.getSummaryTime()
         );
+    }
+
+    private TopicResponseDTO.TopicPreviewListResDTO getTopicPreviewListResDTO(Slice<Topic> topicSlice) {
+        List<TopicResponseDTO.TopicPreviewResDTO> topicList = topicSlice.stream()
+                .map(TopicConverter::toPreviewResDTO)
+                .toList();
+
+        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
+                ? topicList.get(topicList.size() - 1).id()
+                : null;
+
+        return TopicResponseDTO.TopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(topicSlice.hasNext())
+                .topics(topicList)
+                .build();
     }
 }


### PR DESCRIPTION
## Issue 번호
close #71 

## 💻 작업 내용
- 홈 메인화면(토픽 목록 조회) 구현

## ❗️Remark
- summaryTime+id 복합 커서로 구현
- summaryTime을 기준으로 정렬하지만 프론트가 커서로 id를 입력할 수 있도록 설계