### PR TITLE
Fix: 필드명 변경 적용 및 중복 코드 제거

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReportTopicsJpaAdapter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/DailyReportTopicsJpaAdapter.java
@@ -67,7 +67,7 @@ public class DailyReportTopicsJpaAdapter implements DailyReportTopicsPort {
 	private DailyReportEmailTemplate.TopicCard toCard(Topic t) {
 		String base = mailService.getFrontBaseUrl();
 		String link = base + "/topics/" + t.getId();
-		String meta = "업데이트 " + META_TIME_FMT.format(t.getUpdatedAt());
+		String meta = "업데이트 " + META_TIME_FMT.format(t.getSummaryTime());
 		String title = t.getTopicName();
 		String summary = safeSummary(t);
 		String imageUrl = t.getImageUrl();

--- a/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/port/UnsubscribeTokenPort.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/dailyReport/port/UnsubscribeTokenPort.java
@@ -1,7 +1,0 @@
-package UMC.news.newsIntelligent.domain.dailyReport.port;
-
-import UMC.news.newsIntelligent.domain.member.entity.Member;
-
-public interface UnsubscribeTokenPort {
-	String issueToken(Member member);
-}

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
@@ -56,7 +56,7 @@ public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> 
           join mt.topic t
          where mt.member.id = :memberId
            and mt.isSubscribe = true
-         order by t.updatedAt desc
+         order by t.summaryTime desc
     """)
     Page<Topic> findSubscribedTopicsOrderByUpdatedDesc(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
@@ -45,23 +45,4 @@ public class NewsResponseDTO {
             LocalDateTime publishDate,
             List<NewsRelatedArticleDto> relatedArticles
     ) {}
-
-    public record NewsRelatedArticleDto (
-            Long id,
-            String press,
-            String title,
-            String newsSummary,
-            String newLink,
-            String publishDate
-    ) {}
-
-    // “조건을 만족하는 토픽 묶음 중 최신 1개” 반환용 DTO
-    public record TopicQualifiedItemResDTO(
-            Long id,                     // topic_id
-            String title,
-            String newsSummary,
-            String imageUrl,
-            String publish_date,
-            List<NewsRelatedArticleDto> relatedArticles
-    ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/repository/TopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/repository/TopicRepository.java
@@ -41,7 +41,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     @Query("""
         select t
           from Topic t
-         order by t.updatedAt desc
+         order by t.summaryTime desc
     """)
     Page<Topic> findAllOrderByUpdatedDesc(Pageable pageable);
 
@@ -50,7 +50,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
         select t
           from Topic t
          where t.id not in :excludeIds
-         order by t.updatedAt desc
+         order by t.summaryTime desc
     """)
     Page<Topic> findAllExcludingIdsOrderByUpdatedDesc(@Param("excludeIds") Collection<Long> excludeIds, Pageable pageable);
 }


### PR DESCRIPTION
## Issue 번호


## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- rebase 과정에서 레코드 중복 코드가 발생하여 삭제했습니다.
- Topic 엔티티가 BaseEntity를 상속하지 않음에 따라 기존에 updatedAt 필드를 사용하는 부분을 summaryTime 으로 변경하여 적용했습니다.

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
