### PR TITLE
refactor: 최신 수정 보도 조건 완화

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
@@ -43,7 +43,7 @@ public class NewsController {
             @RequestParam(defaultValue = "3") int size
     ) {
         NewsResponseDTO.NewsResDTO response = newsQueryServiceImpl.getRelatedNews(topicId, lastId, size);
-        return CustomResponse.onSuccess(SuccessCode.GET_TOPIC, response);
+        return CustomResponse.onSuccess(SuccessCode.GET_NEWS, response);
     }
 
     @Operation(summary = "최신 수정 보도 조회 API", description = "최신 수정된 기사 수가 3개 이상인 최신 토픽 하나를 반환합니다.")
@@ -53,7 +53,7 @@ public class NewsController {
     @GetMapping("/latest")
     public CustomResponse<NewsResponseDTO.TopicQualifiedItemResDTO> getLatestTopic() {
         NewsResponseDTO.TopicQualifiedItemResDTO latestTopicNews = newsQueryServiceImpl.getLatestTopicNews();
-        return CustomResponse.onSuccess(SuccessCode.GET_TOPIC, latestTopicNews);
+        return CustomResponse.onSuccess(SuccessCode.GET_LATEST_TOPIC, latestTopicNews);
     }
 
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
@@ -40,10 +40,10 @@ public class NewsResponseDTO {
     // “조건을 만족하는 토픽 묶음 중 최신 1개” 반환용 DTO
     public record TopicQualifiedItemResDTO(
             Long id,
-            String title,
-            String newsSummary,
+            String topicName,
+            String aiSummary,
             String imageUrl,
-            LocalDateTime publishDate,
+            LocalDateTime summaryTime,
             List<NewsRelatedArticleDto> relatedArticles
     ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.news.repository;
 
+import UMC.news.newsIntelligent.domain.news.dto.NewsResponseDTO;
 import UMC.news.newsIntelligent.domain.news.entity.News;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,37 +25,51 @@ public interface NewsRepository extends JpaRepository<News, Long> {
 
     int countByTopicId(Long topicId);
 
-//    @Query(value = """
-//        SELECT *
-//        FROM news n
-//        WHERE n.is_new = 1
-//          AND n.is_third = 0
-//          AND n.topic_id IN (
-//            SELECT topic_id
-//            FROM news
-//            WHERE is_new = 1 AND is_third = 0
-//            GROUP BY topic_id
-//            HAVING COUNT(*) >= 3
-//          )
-//        ORDER BY n.topic_id, n.publish_date
-//        """, nativeQuery = true)
-//    List<News> findLatestNews();
-
+    //토픽은 1개 (is_new true, is_third false)를 만족하는 뉴스가 단 하나라도 있다면 선택
     @Query(value = """
-    SELECT n.*
-    FROM news n
-    JOIN (
-        SELECT topic_id
-        FROM news
-        WHERE is_new = 1
-          AND is_third = 0
-        GROUP BY topic_id
-        HAVING COUNT(*) >= 3
-        ORDER BY COUNT(*) DESC, MAX(id) DESC   -- 동률이면 id 큰 토픽 우선
+        SELECT n.topic_id
+        FROM news n
+        WHERE n.is_new = 1
+          AND n.is_third = 0
+        GROUP BY n.topic_id
+        ORDER BY COUNT(*) DESC, MAX(n.id) DESC
         LIMIT 1
-    ) t ON t.topic_id = n.topic_id
-    WHERE n.is_new = 1
-      AND n.is_third = 0
     """, nativeQuery = true)
-    List<News> findArticlesOfTopTopicByCount();
+    Long pickTopTopicIdByQualifiedNews();
+
+    /**
+     * 토픽은 1개 (is_new true, is_third false)를 만족하는 뉴스가 단 하나라도 있다면 선택
+     * 해당 토픽의 기사 3개를 반환하는데, 그중 하나는 (is_new true, is_third false)이 조건을 만족함
+     * 나머지 2개는 조건 무관하게 최신순으로 리턴 기준 완화하려했으나,
+     * sql구문이 매우 복잡해지고 잘못된 값을 불러서.. (is_new true, is_third false)를 만족하는 뉴스만큼 리턴함
+     */
+    @Query(value = """
+        SELECT n.*
+        FROM news n
+        WHERE n.topic_id = :topicId
+          AND n.is_new = 1
+          AND n.is_third = 0
+        ORDER BY n.publish_date DESC, n.id DESC
+        LIMIT 3
+    """, nativeQuery = true)
+    List<News> findTop3QualifiedNewsByTopicId(@Param("topicId") Long topicId);
+
 }
+//    @Query(value = """
+//    SELECT n.*
+//    FROM news n
+//    JOIN (
+//        SELECT topic_id
+//        FROM news
+//        WHERE is_new = 1
+//          AND is_third = 0
+//        GROUP BY topic_id
+//        HAVING COUNT(*) >= 3
+//        ORDER BY COUNT(*) DESC, MAX(id) DESC   -- 동률이면 id 큰 토픽 우선
+//        LIMIT 1
+//    ) t ON t.topic_id = n.topic_id
+//    WHERE n.is_new = 1
+//      AND n.is_third = 0
+//    """, nativeQuery = true)
+//    List<News> findArticlesOfTopTopicByCount();
+

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
@@ -2,10 +2,13 @@ package UMC.news.newsIntelligent.domain.news.service;
 
 import UMC.news.newsIntelligent.domain.news.converter.NewsConverter;
 import UMC.news.newsIntelligent.domain.news.dto.NewsResponseDTO;
+//import UMC.news.newsIntelligent.domain.news.entity.News;
 import UMC.news.newsIntelligent.domain.news.entity.News;
 import UMC.news.newsIntelligent.domain.news.entity.PressLogo;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
 import UMC.news.newsIntelligent.domain.news.repository.PressLogoRepository;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import UMC.news.newsIntelligent.domain.topic.repository.TopicRepository;
 import UMC.news.newsIntelligent.global.apiPayload.code.error.ErrorCode;
 import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,7 @@ public class NewsQueryServiceImpl implements NewsQueryService{
     private static final int MAX_PAGE_SIZE = 20;
     private static final String DEFAULT_LOGO = null; // 기본 로고
 
+    private final TopicRepository topicRepository;
     private final NewsRepository newsRepository;
     private final PressLogoRepository pressLogoRepository;
 
@@ -51,55 +55,32 @@ public class NewsQueryServiceImpl implements NewsQueryService{
         return new NewsResponseDTO.NewsResDTO(content, totalCount, newLastId, pageSize, hasNext);
     }
 
-    // 최신 수정 보도 (조건 만족 + 같은 topic_id로 3개 이상 중 '기사 수가 가장많은' 토픽 1개)
+    // 최신 수정 보도 (조건 만족 + 같은 topic_id로 1개 이상인 토픽 1개)
     @Override
     public NewsResponseDTO.TopicQualifiedItemResDTO getLatestTopicNews() throws CustomException {
-        List<News> latestNews = newsRepository.findArticlesOfTopTopicByCount();
-
-        if (latestNews.isEmpty()) {
-            throw new CustomException(ErrorCode.LATEST_NEWS_NOT_FOUND);
+        Long qualifiedTopic = newsRepository.pickTopTopicIdByQualifiedNews();
+        if (qualifiedTopic == null) {
+            throw new CustomException(ErrorCode.TOPIC_NOT_FOUND);
         }
 
-        // 최신순 정렬
-        latestNews.sort(
-                Comparator.comparing(News::getPublishDate)
-                        .thenComparing(News::getId)
-                        .reversed()
-        );
+        Topic topic = topicRepository.findById(qualifiedTopic)
+                .orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
 
-        Long topicId = latestNews.get(0).getTopic().getId();
-
-        // 대표 기사: 정렬 결과의 첫 번째(= 가장 최신 기사)
-        News main = latestNews.get(0);
-
-        List<NewsResponseDTO.NewsRelatedArticleDto> related = NewsConverter.toRelatedDtos(latestNews);
+        List<News> relatedNewsEntity = newsRepository.findTop3QualifiedNewsByTopicId(qualifiedTopic);
+        if (relatedNewsEntity.isEmpty()) {
+            throw new CustomException(ErrorCode.LATEST_NEWS_NOT_FOUND);
+        }
+        List<NewsResponseDTO.NewsRelatedArticleDto> relatedNews =
+                NewsConverter.toRelatedDtos(relatedNewsEntity);
 
         return new NewsResponseDTO.TopicQualifiedItemResDTO(
-                topicId,
-                main.getTitle(),
-                main.getNewsSummary(),
-                main.getTopic().getImageUrl(),
-                main.getPublishDate(),
-                related
+                topic.getId(),
+                topic.getTopicName(),
+                topic.getAiSummary(),
+                topic.getImageUrl(),
+                topic.getSummaryTime(),
+                relatedNews
         );
-
-//        // topic_id 단위로 그룹핑
-//        Map<Long, List<News>> byTopic = latestNews.stream()
-//                .collect(Collectors.groupingBy(n -> n.getTopic().getId(), LinkedHashMap::new, Collectors.toList()));
-//
-//        // 개수가 가장 많은 토픽 그룹 선택 (동률이면 첫 그룹)
-//        Map.Entry<Long, List<News>> mostCountGroup = byTopic.entrySet().stream()
-//                .max(Comparator.comparingInt(e -> e.getValue().size()))
-//                .orElseThrow(() -> new CustomException(GeneralErrorCode.LATEST_NEWS_NOT_FOUND));
-//
-//        Long topicId = mostCountGroup.getKey();
-//        List<News> items = mostCountGroup.getValue();
-//
-//        // 대표 기사: id가 가장 큰 기사
-//        News main = items.stream()
-//                .max(Comparator.comparing(News::getId))
-//                .orElse(items.get(0));
-
     }
 
     private static int normalizeSize(int size) {

--- a/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/success/SuccessCode.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/success/SuccessCode.java
@@ -26,9 +26,9 @@ public enum SuccessCode implements BaseSuccessCode{
 
 
     // 토픽
-    GET_TOPIC(HttpStatus.OK, "TOPIC200", "토픽 상세 페이지 조회가 완료되었습니다."),
-    GET_NEWS(HttpStatus.OK, "NEWS200", "토픽 출처 기사 목록 조회가 완료되었습니다."),
-    GET_LATEST_TOPIC(HttpStatus.OK, "TOPIC200", "최신 수정 보도 조회가 완료되었습니다."),
+    GET_TOPIC(HttpStatus.OK, "TOPIC_PAGE200", "토픽 상세 페이지 조회가 완료되었습니다."),
+    GET_NEWS(HttpStatus.OK, "TOPIC_NEWS200", "토픽 출처 기사 목록 조회가 완료되었습니다."),
+    GET_LATEST_TOPIC(HttpStatus.OK, "LATEST_TOPIC200", "최신 수정 보도 조회가 완료되었습니다."),
 
     // 피드백
     FEEDBACK_CREATED(HttpStatus.CREATED, "FEEDBACK2001", "성공적으로 피드백이 생성했습니다.");


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #82 

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용

     - 토픽은 1개 (is_new true, is_third false)를 만족하는 뉴스가 단 하나라도 있다면 선택
     - 해당 토픽의 기사 3개를 반환하는데, 그중 하나는 (is_new true, is_third false)이 조건을 만족함
     - 나머지 2개는 조건 무관하게 최신순으로 리턴 기준 완화하려했으나,
     - sql구문이 매우 매우 복잡해지고 결과가 잘못된 값을 불러서.. (is_new true, is_third false)를 만족하는 뉴스만큼 리턴함
     - 현재는 만족하는 뉴스가 단 하나뿐임... 
     - 혹시 몰라서 기존 repository 쿼리는 남겨둠 

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
