### PR TITLE
Feat: 이미지 출처 기사 반환 구현

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
@@ -1,19 +1,36 @@
 package UMC.news.newsIntelligent.domain.member.converter;
 
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
+import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+
+import java.util.List;
+import java.util.Map;
 
 public class MemberTopicConverter {
 
-    public static MemberTopicResponseDTO.MemberTopicPreviewResDTO toPreviewResDTO(Topic topic) {
-
+    // 단건 매핑
+    public static MemberTopicResponseDTO.MemberTopicPreviewResDTO toPreviewResDTO(
+            Topic topic,
+            TopicResponseDTO.ImageSource imageSource
+    ) {
         return MemberTopicResponseDTO.MemberTopicPreviewResDTO.builder()
                 .id(topic.getId())
                 .topicName(topic.getTopicName())
                 .aiSummary(topic.getAiSummary())
-                .imageUrl(topic.getImageUrl())
                 .summaryTime(topic.getSummaryTime())
+                .imageUrl(topic.getImageUrl())
+                .imageSource(imageSource)
                 .build();
     }
 
+    // 리스트 매핑
+    public static List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> toPreviewResDTOList(
+            List<Topic> topics,
+            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap
+    ) {
+        return topics.stream()
+                .map(t -> toPreviewResDTO(t, imageSourceMap.get(t.getId())))
+                .toList();
+    }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberTopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberTopicResponseDTO.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.member.dto;
 
+import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,7 +16,8 @@ public class MemberTopicResponseDTO {
             String topicName,
             String aiSummary,
             LocalDateTime summaryTime,
-            String imageUrl
+            String imageUrl,
+            TopicResponseDTO.ImageSource imageSource
     ) {}
 
     @Builder

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -3,6 +3,9 @@ package UMC.news.newsIntelligent.domain.member.service;
 import UMC.news.newsIntelligent.domain.member.converter.MemberTopicConverter;
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
 import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
+import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
+import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
+import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +23,7 @@ import java.util.List;
 public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
 
     private final MemberTopicRepository memberTopicRepository;
+    private final NewsRepository newsRepository;
 
     @Override
     public MemberTopicResponseDTO.MemberTopicPreviewListResDTO searchReadTopics(String keyword, Long cursor, int size, Long memberId) {
@@ -28,17 +33,8 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = memberTopicRepository.searchReadTopicsByKeyword(memberId, keyword, cursor, pageable);
 
-        List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(MemberTopicConverter::toPreviewResDTO)
-                .toList();
-
-        Long nextCursor = topicSlice.hasNext() ? topicList.get(topicList.size() - 1).id() : null;
-
-        return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
-                .build();
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
+        return toPreviewList(topicSlice, srcMap);
     }
 
     @Override
@@ -49,17 +45,8 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = memberTopicRepository.getReadTopicsByMemberId(memberId, cursor, pageable);
 
-        List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(MemberTopicConverter::toPreviewResDTO)
-                .toList();
-
-        Long nextCursor = topicSlice.hasNext() ? topicList.get(topicList.size() - 1).id() : null;
-
-        return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
-                .build();
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
+        return toPreviewList(topicSlice, srcMap);
     }
 
     @Override
@@ -70,18 +57,46 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = memberTopicRepository.getSubscriptionTopicsByMemberId(memberId, cursor, pageable);
 
-        List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(MemberTopicConverter::toPreviewResDTO)
-                .toList();
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
+        return toPreviewList(topicSlice, srcMap);
+    }
 
-        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
-                ? topicList.get(topicList.size() - 1).id()
+    // 해당 페이지 기사들 한 번에 조회 -> Map
+    private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromSlice(Slice<Topic> slice) {
+        List<Long> topicIds = slice.getContent().stream()
+                .map(Topic::getId).toList();
+
+        if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
+
+        // OldestPerTopicProjection: (topicId, press, title) 를 가진 프로젝션
+        List<OldestPerTopicProjection> oldestList = newsRepository.findOldestPerTopic(topicIds);
+
+        return oldestList.stream().collect(
+                java.util.stream.Collectors.toMap(
+                        OldestPerTopicProjection::getTopicId,
+                        p -> TopicResponseDTO.ImageSource.builder()
+                                .press(p.getPress())
+                                .title(p.getTitle())
+                                .build(),
+                        (a, b) -> a
+                )
+        );
+    }
+
+    private MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
+            Slice<Topic> slice,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap
+    ) {
+        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap);
+
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
+                ? topics.get(topics.size() - 1).id()
                 : null;
 
         return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
                 .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
+                .hasNext(slice.hasNext())
+                .topics(topics)
                 .build();
     }
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
@@ -27,8 +27,8 @@ public class NewsController {
             @ApiResponse(responseCode = "200", description = "토픽 상세 페이지 조회 성공")
     })
     @GetMapping("/{topicId}")
-    public CustomResponse<TopicResponseDTO.TopicDetailsResDTO> getTopicDetails(@PathVariable Long topicId){
-        TopicResponseDTO.TopicDetailsResDTO topicDetailsDTO = topicQueryService.getTopicById(topicId);
+    public CustomResponse<TopicResponseDTO.TopicPreviewResDTO> getTopicDetails(@PathVariable Long topicId){
+        TopicResponseDTO.TopicPreviewResDTO topicDetailsDTO = topicQueryService.getTopicById(topicId);
         return CustomResponse.onSuccess(SuccessCode.GET_TOPIC, topicDetailsDTO);
     }
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/converter/NewsConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/converter/NewsConverter.java
@@ -2,14 +2,16 @@ package UMC.news.newsIntelligent.domain.news.converter;
 
 import UMC.news.newsIntelligent.domain.news.dto.NewsResponseDTO;
 import UMC.news.newsIntelligent.domain.news.entity.News;
+import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public final class NewsConverter {
     private NewsConverter() {}
 
-    /** 단건 변환 */
     public static NewsResponseDTO.NewsListResDTO toListResDTO(News n, String pressLogoUrl) {
         return new NewsResponseDTO.NewsListResDTO(
                 n.getId(),
@@ -22,14 +24,13 @@ public final class NewsConverter {
         );
     }
 
-    /** 배치 변환 (press -> logoUrl 맵을 주입 받아 사용) */
+    // 리스트 매핑
     public static List<NewsResponseDTO.NewsListResDTO> toListResDTOs(
-            List<News> newsList,
-            Map<String, String> pressLogoMap,
-            String defaultLogoUrl
+            List<News> items,
+            Function<String, String> logoResolver
     ) {
-        return newsList.stream()
-                .map(n -> toListResDTO(n, pressLogoMap.getOrDefault(n.getPress(), defaultLogoUrl)))
+        return items.stream()
+                .map(n -> toListResDTO(n, logoResolver.apply(n.getPress())))
                 .toList();
     }
 
@@ -47,5 +48,21 @@ public final class NewsConverter {
 
     public static List<NewsResponseDTO.NewsRelatedArticleDto> toRelatedDtos(List<News> news) {
         return news.stream().map(NewsConverter::toRelatedDto).toList();
+    }
+
+    public static NewsResponseDTO.TopicQualifiedItemResDTO toTopicQualifiedItem(
+            Topic topic,
+            NewsResponseDTO.ImageSource imageSource,
+            List<NewsResponseDTO.NewsRelatedArticleDto> related
+    ) {
+        return NewsResponseDTO.TopicQualifiedItemResDTO.builder()
+                .id(topic.getId())
+                .topicName(topic.getTopicName())
+                .aiSummary(topic.getAiSummary())
+                .imageUrl(topic.getImageUrl())
+                .summaryTime(topic.getSummaryTime())
+                .imageSource(imageSource)
+                .relatedArticles(related)
+                .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
@@ -1,10 +1,13 @@
 package UMC.news.newsIntelligent.domain.news.dto;
 
+import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Getter
 public class NewsResponseDTO {
 
 
@@ -28,6 +31,7 @@ public class NewsResponseDTO {
             String pressLogoUrl
     ) {}
 
+    @Builder
     public record NewsRelatedArticleDto (
             Long id,
             String press,
@@ -38,12 +42,20 @@ public class NewsResponseDTO {
     ) {}
 
     // “조건을 만족하는 토픽 묶음 중 최신 1개” 반환용 DTO
+    @Builder
     public record TopicQualifiedItemResDTO(
             Long id,
             String topicName,
             String aiSummary,
             String imageUrl,
             LocalDateTime summaryTime,
+            ImageSource imageSource,
             List<NewsRelatedArticleDto> relatedArticles
+    ) {}
+
+    @Builder
+    public record ImageSource(
+            String press,
+            String title
     ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/entity/LatestCorrection.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/entity/LatestCorrection.java
@@ -1,0 +1,30 @@
+package UMC.news.newsIntelligent.domain.news.entity;
+
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import UMC.news.newsIntelligent.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "latest_correction",
+        uniqueConstraints = @UniqueConstraint(name="uk_latest_topic", columnNames = "topic_id"))
+public class LatestCorrection extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "topic_id", nullable = false)
+    private Topic topic;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/LatestCorrectionRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/LatestCorrectionRepository.java
@@ -1,0 +1,16 @@
+package UMC.news.newsIntelligent.domain.news.repository;
+
+import UMC.news.newsIntelligent.domain.news.entity.LatestCorrection;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LatestCorrectionRepository extends JpaRepository<LatestCorrection, Long> {
+    Optional<LatestCorrection> findByTopicId(Long topicId);
+
+    @Query("select lc from LatestCorrection lc order by lc.createdAt desc")
+    List<LatestCorrection> findRecent(Pageable pageable);
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
@@ -1,13 +1,14 @@
 package UMC.news.newsIntelligent.domain.news.repository;
 
-import UMC.news.newsIntelligent.domain.news.dto.NewsResponseDTO;
 import UMC.news.newsIntelligent.domain.news.entity.News;
+import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
 
@@ -54,6 +55,26 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     """, nativeQuery = true)
     List<News> findTop3QualifiedNewsByTopicId(@Param("topicId") Long topicId);
 
+    @Query("""
+SELECT n.topic.id AS topicId, n.press AS press, n.title AS title
+FROM News n
+WHERE n.topic.id IN :topicIds
+  AND n.publishDate = (
+      SELECT MIN(n2.publishDate)
+      FROM News n2
+      WHERE n2.topic.id = n.topic.id
+  )
+  AND n.id = (
+      SELECT MAX(n3.id)
+      FROM News n3
+      WHERE n3.topic.id = n.topic.id
+        AND n3.publishDate = n.publishDate
+  )
+""")
+    List<OldestPerTopicProjection> findOldestPerTopic(java.util.Collection<Long> topicIds);
+
+    // 특정 토픽 내에서 가장 오래된 publishDate, id가 가장 큰 기사
+    Optional<News> findFirstByTopicIdOrderByPublishDateAscIdDesc(Long topicId);
 }
 //    @Query(value = """
 //    SELECT n.*

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/projection/OldestPerTopicProjection.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/projection/OldestPerTopicProjection.java
@@ -1,0 +1,7 @@
+package UMC.news.newsIntelligent.domain.news.repository.projection;
+
+public interface OldestPerTopicProjection {
+    Long getTopicId();
+    String getPress();
+    String getTitle();
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/LatestCorrectionQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/LatestCorrectionQueryService.java
@@ -1,0 +1,4 @@
+package UMC.news.newsIntelligent.domain.news.service;
+
+public class LatestCorrectionQueryService {
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
@@ -46,9 +46,8 @@ public class NewsQueryServiceImpl implements NewsQueryService{
 
         Map<String, String> logoMap = loadPressLogos(pageItems);
 
-        List<NewsResponseDTO.NewsListResDTO> content = pageItems.stream()
-                .map(n -> NewsConverter.toListResDTO(n, logoFor(n.getPress(), logoMap)))
-                .toList();
+        List<NewsResponseDTO.NewsListResDTO> content =
+                NewsConverter.toListResDTOs(pageItems, press -> logoFor(press, logoMap));
 
         Long newLastId = content.isEmpty() ? null : content.get(content.size() - 1).id();
 
@@ -73,14 +72,16 @@ public class NewsQueryServiceImpl implements NewsQueryService{
         List<NewsResponseDTO.NewsRelatedArticleDto> relatedNews =
                 NewsConverter.toRelatedDtos(relatedNewsEntity);
 
-        return new NewsResponseDTO.TopicQualifiedItemResDTO(
-                topic.getId(),
-                topic.getTopicName(),
-                topic.getAiSummary(),
-                topic.getImageUrl(),
-                topic.getSummaryTime(),
-                relatedNews
-        );
+        // 출처 기사
+        var source = newsRepository.findFirstByTopicIdOrderByPublishDateAscIdDesc(qualifiedTopic);
+        NewsResponseDTO.ImageSource imageSource = source
+                .map(n -> NewsResponseDTO.ImageSource.builder()
+                        .press(n.getPress())
+                        .title(n.getTitle())
+                        .build())
+                .orElse(null);
+
+        return NewsConverter.toTopicQualifiedItem(topic, imageSource, relatedNews);
     }
 
     private static int normalizeSize(int size) {

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
@@ -1,17 +1,35 @@
 package UMC.news.newsIntelligent.domain.topic.converter;
 
-import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+
+import java.util.List;
+import java.util.Map;
 
 public class TopicConverter {
 
-    public static TopicResponseDTO.TopicPreviewResDTO toPreviewResDTO(Topic topic) {
+    // 단건 매핑
+    public static TopicResponseDTO.TopicPreviewResDTO toPreviewResDTO(
+            Topic topic,
+            TopicResponseDTO.ImageSource imageSource
+    ) {
         return TopicResponseDTO.TopicPreviewResDTO.builder()
                 .id(topic.getId())
                 .topicName(topic.getTopicName())
                 .aiSummary(topic.getAiSummary())
-                .imageUrl(topic.getImageUrl())
                 .summaryTime(topic.getSummaryTime())
+                .imageUrl(topic.getImageUrl())
+                .imageSource(imageSource)
                 .build();
+    }
+
+    // 리스트 매핑
+    public static List<TopicResponseDTO.TopicPreviewResDTO> toPreviewResDTOList(
+            List<Topic> topics,
+            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap
+    ) {
+        return topics.stream()
+                .map(t -> toPreviewResDTO(t, imageSourceMap.get(t.getId())))
+                .toList();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
@@ -15,7 +15,8 @@ public class TopicResponseDTO {
             String topicName,
             String aiSummary,
             LocalDateTime summaryTime,
-            String imageUrl
+            String imageUrl,
+            ImageSource imageSource
     ) {}
 
     @Builder
@@ -23,5 +24,11 @@ public class TopicResponseDTO {
             Long cursor,
             Boolean hasNext,
             List<TopicPreviewResDTO> topics
+    ) {}
+
+    @Builder
+    public record ImageSource(
+            String press,
+            String title
     ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
@@ -24,13 +24,4 @@ public class TopicResponseDTO {
             Boolean hasNext,
             List<TopicPreviewResDTO> topics
     ) {}
-
-    @Builder
-    public record TopicDetailsResDTO(
-            Long id,
-            String topicName,
-            String aiSummary,
-            String imageUrl,
-            LocalDateTime summaryTime
-    ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
@@ -8,5 +8,5 @@ public interface TopicQueryService {
 
     TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size);
 
-    TopicResponseDTO.TopicDetailsResDTO getTopicById(Long topicId);
+    TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package UMC.news.newsIntelligent.domain.topic.service.query;
 
-import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import UMC.news.newsIntelligent.domain.news.entity.News;
+import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
+import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
 import UMC.news.newsIntelligent.domain.topic.converter.TopicConverter;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import UMC.news.newsIntelligent.domain.topic.repository.TopicRepository;
 import UMC.news.newsIntelligent.global.apiPayload.code.error.ErrorCode;
 import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ import java.util.List;
 public class TopicQueryServiceImpl implements TopicQueryService {
 
     private final TopicRepository topicRepository;
+    private final NewsRepository newsRepository;
 
     @Override
     public TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size) {
@@ -31,7 +36,8 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Topic> topicSlice = topicRepository.findByKeywordAndCursor(keyword, cursor, pageable);
 
-        return getTopicPreviewListResDTO(topicSlice);
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
+        return mapSliceToPreviewListDTO(topicSlice, srcMap);
     }
 
     private Long normalizeCursor(Long cursor) {
@@ -55,26 +61,14 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         // 첫 페이지: cursor == null -> 최신부터
         if (cursor != null && cursor != 0) {
             Topic last = topicRepository.findById(cursor).orElse(null);
-            if (last != null) {
-                cursorTime = last.getSummaryTime();
-                cursorId   = last.getId();
-            } else {
-                throw new CustomException(ErrorCode.CURSOR_INVALID);
-            }
+            if (last == null) throw new CustomException(ErrorCode.CURSOR_INVALID);
+            cursorTime = last.getSummaryTime();
+            cursorId = last.getId();
         }
 
         Slice<Topic> slice = topicRepository.findByCursorOrderBySummaryTimeDesc(cursorTime, cursorId, pageable);
-
-        // 커서는 마지막 아이템의 id
-        List<TopicResponseDTO.TopicPreviewResDTO> topics = slice.getContent()
-                .stream().map(TopicConverter::toPreviewResDTO).toList();
-        Long nextCursor = (slice.hasNext() && !topics.isEmpty()) ? topics.get(topics.size()-1).id() : null;
-
-        return TopicResponseDTO.TopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(slice.hasNext())
-                .topics(topics)
-                .build();
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(slice);
+        return mapSliceToPreviewListDTO(slice, srcMap);
     }
 
     @Override
@@ -82,28 +76,61 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
 
+        News oldest = newsRepository.findFirstByTopicIdOrderByPublishDateAscIdDesc(topicId).orElse(null);
+
+        TopicResponseDTO.ImageSource imageSource = (oldest == null) ? null
+                : TopicResponseDTO.ImageSource.builder()
+                .press(oldest.getPress())
+                .title(oldest.getTitle())
+                .build();
+
         return new TopicResponseDTO.TopicPreviewResDTO(
                 topic.getId(),
                 topic.getTopicName(),
                 topic.getAiSummary(),
                 topic.getSummaryTime(),
-                topic.getImageUrl()
+                topic.getImageUrl(),
+                imageSource
         );
     }
 
-    private TopicResponseDTO.TopicPreviewListResDTO getTopicPreviewListResDTO(Slice<Topic> topicSlice) {
-        List<TopicResponseDTO.TopicPreviewResDTO> topicList = topicSlice.stream()
-                .map(TopicConverter::toPreviewResDTO)
+    // // 해당 페이지 topicId 수집 후 각 토픽의 출처 기사 한 번에 조회 -> Map
+    private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromSlice(Slice<Topic> slice) {
+        List<Long> topicIds = slice.getContent().stream()
+                .map(Topic::getId)
                 .toList();
 
-        Long nextCursor = (topicSlice.hasNext() && !topicList.isEmpty())
-                ? topicList.get(topicList.size() - 1).id()
+        if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
+
+        List<OldestPerTopicProjection> oldestList = newsRepository.findOldestPerTopic(topicIds);
+
+        return oldestList.stream().collect(
+                java.util.stream.Collectors.toMap(
+                        OldestPerTopicProjection::getTopicId,
+                        p -> TopicResponseDTO.ImageSource.builder()
+                                .press(p.getPress())
+                                .title(p.getTitle())
+                                .build(),
+                        (a, b) -> a
+                )
+        );
+    }
+
+    private TopicResponseDTO.TopicPreviewListResDTO mapSliceToPreviewListDTO(
+            Slice<Topic> slice,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap
+    ) {
+        List<TopicResponseDTO.TopicPreviewResDTO> topics =
+                TopicConverter.toPreviewResDTOList(slice.getContent(), srcMap);
+
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
+                ? topics.get(topics.size() - 1).id()
                 : null;
 
         return TopicResponseDTO.TopicPreviewListResDTO.builder()
                 .cursor(nextCursor)
-                .hasNext(topicSlice.hasNext())
-                .topics(topicList)
+                .hasNext(slice.hasNext())
+                .topics(topics)
                 .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -78,16 +78,16 @@ public class TopicQueryServiceImpl implements TopicQueryService {
     }
 
     @Override
-    public TopicResponseDTO.TopicDetailsResDTO getTopicById(Long topicId) {
+    public TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId) {
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
 
-        return new TopicResponseDTO.TopicDetailsResDTO(
+        return new TopicResponseDTO.TopicPreviewResDTO(
                 topic.getId(),
                 topic.getTopicName(),
                 topic.getAiSummary(),
-                topic.getImageUrl(),
-                topic.getSummaryTime()
+                topic.getSummaryTime(),
+                topic.getImageUrl()
         );
     }
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -76,12 +76,12 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
 
-        News oldest = newsRepository.findFirstByTopicIdOrderByPublishDateAscIdDesc(topicId).orElse(null);
+        News source = newsRepository.findFirstByTopicIdOrderByPublishDateAscIdDesc(topicId).orElse(null);
 
-        TopicResponseDTO.ImageSource imageSource = (oldest == null) ? null
+        TopicResponseDTO.ImageSource imageSource = (source == null) ? null
                 : TopicResponseDTO.ImageSource.builder()
-                .press(oldest.getPress())
-                .title(oldest.getTitle())
+                .press(source.getPress())
+                .title(source.getTitle())
                 .build();
 
         return new TopicResponseDTO.TopicPreviewResDTO(
@@ -102,9 +102,9 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
         if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
 
-        List<OldestPerTopicProjection> oldestList = newsRepository.findOldestPerTopic(topicIds);
+        List<OldestPerTopicProjection> sourceList = newsRepository.findOldestPerTopic(topicIds);
 
-        return oldestList.stream().collect(
+        return sourceList.stream().collect(
                 java.util.stream.Collectors.toMap(
                         OldestPerTopicProjection::getTopicId,
                         p -> TopicResponseDTO.ImageSource.builder()

--- a/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/error/ErrorCode.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/apiPayload/code/error/ErrorCode.java
@@ -26,9 +26,9 @@ public enum ErrorCode implements BaseErrorCode{
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION400", "해당 알림을 찾을 수 없습니다."),
     // 토픽 관련 에러
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC404_1", "해당 토픽을 찾을 수 없습니다."),
-    MEMBERTOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC401", "해당 멤버와 관계를 가진 토픽을 찾을 수 없습니다."),
+    MEMBERTOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC404_2", "해당 멤버와 관계를 가진 토픽을 찾을 수 없습니다."),
     // 최신 수정 보도 관련 에러
-    LATEST_NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC404_2", "기사 수 3개 이상을 만족하는 최신 수정 보도가 없습니다."),
+    LATEST_NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "TOPIC404_3", "기사 수 3개 이상을 만족하는 최신 수정 보도가 없습니다."),
 
     // 데일리 리포트 관련 에러
     DAILY_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT400", "데일리 리포트를 찾을 수 없습니다."),


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #78 

## 💻 작업 내용
- [x] 최신 수정 보도 테이블(latest_correction) 생성
- [x] 토픽 조회 api들 response에 이미지 출처 기사 필드 포함하도록 수정
    - 최신 수정 보도 조회
    - 토픽 목록(홈화면) 조회
    - 토픽 검색 결과 조회
    - 토픽 상세 페이지 조회
    - 구독 토픽 리스트 조회
    - 읽은 토픽 목록 리스트 조회
    - 읽은 토픽 목록 내 조회
- [x] 변경된 api 전부 테스트 완료

## 🖼️ 관련 스크린샷 (선택)
<img width="768" height="538" alt="image" src="https://github.com/user-attachments/assets/6aac11a5-037e-4666-9bae-4befdf50c2d8" />


## ❗️Remark

