### PR TITLE
Refactor : 로그인 멤버만 작성 가능한 feedback을 모든 사용자가 작성 가능하게 리펙토링

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/feedback/controller/FeedbackController.java
@@ -2,16 +2,12 @@ package UMC.news.newsIntelligent.domain.feedback.controller;
 
 import UMC.news.newsIntelligent.domain.feedback.dto.FeedbackRequestDTO;
 import UMC.news.newsIntelligent.domain.feedback.service.command.FeedbackCommandService;
-import UMC.news.newsIntelligent.domain.member.entity.Member;
 import UMC.news.newsIntelligent.global.apiPayload.CustomResponse;
 import UMC.news.newsIntelligent.global.apiPayload.code.success.SuccessCode;
 import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
-import UMC.news.newsIntelligent.global.config.security.PrincipalUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,12 +24,9 @@ public class FeedbackController {
     /* --- 피드백 작성 --- */
     @Operation(summary = "피드백 작성", description = "사용자가 불편함을 느끼는 피드백을 받는 API입니다.")
     @PostMapping("/feedbacks")
-    public CustomResponse<?> submitFeedback(
-            @RequestBody FeedbackRequestDTO.FeedbackRequest request,
-            @AuthenticationPrincipal PrincipalUserDetails principal
-            ) {
+    public CustomResponse<?> submitFeedback(@RequestBody FeedbackRequestDTO.FeedbackRequest request) {
         try {
-            feedbackCommandService.submitFeedback(request, principal.getMemberId());
+            feedbackCommandService.submitFeedback(request);
             return CustomResponse.onSuccess(SuccessCode.FEEDBACK_CREATED);
 
         } catch (CustomException e) {

--- a/src/main/java/UMC/news/newsIntelligent/domain/feedback/entity/Feedback.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/feedback/entity/Feedback.java
@@ -27,9 +27,10 @@ public class Feedback extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Member member;
+	// 모든 사용자가 피드백을 제공할 수 있도록 주석처리
+//	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+//	@JoinColumn(name = "member_id", nullable = false)
+//	private Member member;
 
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;

--- a/src/main/java/UMC/news/newsIntelligent/domain/feedback/service/command/FeedbackCommandService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/feedback/service/command/FeedbackCommandService.java
@@ -3,5 +3,5 @@ package UMC.news.newsIntelligent.domain.feedback.service.command;
 import UMC.news.newsIntelligent.domain.feedback.dto.FeedbackRequestDTO;
 
 public interface FeedbackCommandService {
-    void submitFeedback(FeedbackRequestDTO.FeedbackRequest request, Long memberId);
+    void submitFeedback(FeedbackRequestDTO.FeedbackRequest request);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/feedback/service/command/FeedbackCommandServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/feedback/service/command/FeedbackCommandServiceImpl.java
@@ -15,20 +15,15 @@ import org.springframework.stereotype.Service;
 public class FeedbackCommandServiceImpl implements FeedbackCommandService {
 
     private final FeedbackRepository feedbackRepository;
-    private final MemberRepository memberRepository;
 
     @Override
-    public void submitFeedback(FeedbackRequestDTO.FeedbackRequest request, Long memberId) {
-        // 피드백 내용이 null이거나 빈칸인 경우 customException 발생
+    public void submitFeedback(FeedbackRequestDTO.FeedbackRequest request) {
+        // 피드백 내용이 null 이거나 빈칸인 경우 customException 발생
         if (request.content() == null || request.content().isBlank()) {
             throw new CustomException(ErrorCode.FEEDBACK_EMPTY_CONTENT);
         }
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
         Feedback feedback = Feedback.builder()
-                .member(member)
                 .content(request.content())
                 .build();
 


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #90 

## ✅ PR 전 확인!
- [X] 변경 사항에 대한 테스트 완료
- [X] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- Feedback Entity의 Member member 속성 제거
- FeedbackController - Principal에서 memberId를 받아와 인증된 사용자만 피드백 작성이 가능하던 것을 모든 사용자가 피드백 작성이 가능하게 변경
- FeedbackService - feedback에 어떤 멤버가 작성한 것인지 저장이 되는 것을 삭제
<!-- 무엇을 왜 수정했는지 설명하면 리뷰어에게 도움이 됩니다!-->
- 내용

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
