### PR TITLE
Refactor: 회원가입 반환 형식 변경 및 리팩터링

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
@@ -21,6 +21,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 
 @RestController
 @RequestMapping("/api/members")
@@ -87,12 +90,14 @@ public class AuthController {
     @GetMapping("/signup/magic")
     public RedirectView signupMagic(@RequestParam String token) {
         TokenResponseDto tr = authService.signupByToken(token);
-        return new RedirectView("/signup/success" + tr.accessToken());
+        String at = URLEncoder.encode(tr.accessToken(), StandardCharsets.UTF_8);
+        return new RedirectView("/signup/magic-success#" + at);
     }
     @Operation(summary = "리다이렉트용", description = "프론트엔드에서 구현 필요 X")
     @GetMapping("/login/magic")
     public RedirectView loginMagic(@RequestParam String token) {
         TokenResponseDto tr = authService.loginByToken(token);
-        return new RedirectView("/login/magic-success#" + tr.accessToken());
+        String at = URLEncoder.encode(tr.accessToken(), StandardCharsets.UTF_8);
+        return new RedirectView("/login/magic-success#" + at);
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
@@ -3,7 +3,6 @@ package UMC.news.newsIntelligent.domain.member.controller;
 import UMC.news.newsIntelligent.domain.mail.dto.EmailRequestDto;
 import UMC.news.newsIntelligent.domain.mail.dto.VerifyRequestDto;
 import UMC.news.newsIntelligent.domain.mail.entity.OtpCode;
-import UMC.news.newsIntelligent.domain.member.dto.MemberResponseDto;
 import UMC.news.newsIntelligent.domain.member.dto.TokenResponseDto;
 import UMC.news.newsIntelligent.domain.member.entity.Member;
 import UMC.news.newsIntelligent.domain.member.repository.MemberRepository;
@@ -50,8 +49,8 @@ public class AuthController {
     /* 인증 코드 검증 */
     @Operation(summary = "회원가입 인증코드 검증", description = "회원가입 시 전송된 6자리 코드를 검증하는 API입니다.")
     @PostMapping("/signup/verify")
-    public CustomResponse<MemberResponseDto>  signupVerify(@RequestBody VerifyRequestDto request) {
-        MemberResponseDto responseDto = authService.signupByCode(request.email(), request.code());
+    public CustomResponse<TokenResponseDto>  signupVerify(@RequestBody VerifyRequestDto request) {
+        TokenResponseDto responseDto = authService.signupByCode(request.email(), request.code());
         return CustomResponse.onSuccess(SuccessCode.SIGNUP_SUCCESS, responseDto);
     }
     @Operation(summary = "로그인 인증코드 검증", description = "로그인 시 전송된 6자리 코드를 검증하는  API입니다.")
@@ -87,8 +86,8 @@ public class AuthController {
     @Operation(summary = "리다이렉트용", description = "프론트엔드에서 구현 필요 X")
     @GetMapping("/signup/magic")
     public RedirectView signupMagic(@RequestParam String token) {
-        authService.signupByToken(token);
-        return new RedirectView("/signup/success");
+        TokenResponseDto tr = authService.signupByToken(token);
+        return new RedirectView("/signup/success" + tr.accessToken());
     }
     @Operation(summary = "리다이렉트용", description = "프론트엔드에서 구현 필요 X")
     @GetMapping("/login/magic")

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/controller/AuthController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
@@ -33,6 +34,9 @@ public class AuthController {
 
     private final AuthService authService;
     private final MemberRepository memberRepository;
+
+    @Value("${server.host.front}")
+    private String frontHost;
 
     /* 메일 발송 */
     @Operation(summary = "회원가입 인증번호 전송", description = "회원가입 시 사용자에게 이메일로 인증번호를 전송하는 API입니다.")
@@ -84,20 +88,30 @@ public class AuthController {
         return CustomResponse.onSuccess(SuccessCode.WITHDRAW_SUCCESS);
     }
 
+    /* 리다이렉트 처리용 */
+    private RedirectView redirectWithFragment(String path, TokenResponseDto tr) {
+        String token = URLEncoder.encode(tr.accessToken(), StandardCharsets.UTF_8);
+        String exp   = URLEncoder.encode(tr.expiresAt(),   StandardCharsets.UTF_8);
+
+        String url = frontHost + path + "#token=" + token + "&exp=" + exp;
+
+        RedirectView rv = new RedirectView(url);
+        rv.setExposeModelAttributes(false);
+        rv.setContextRelative(false);
+        return rv;
+    }
 
     /* 매직 링크 */
     @Operation(summary = "리다이렉트용", description = "프론트엔드에서 구현 필요 X")
     @GetMapping("/signup/magic")
     public RedirectView signupMagic(@RequestParam String token) {
         TokenResponseDto tr = authService.signupByToken(token);
-        String at = URLEncoder.encode(tr.accessToken(), StandardCharsets.UTF_8);
-        return new RedirectView("/signup/magic-success#" + at);
+        return redirectWithFragment("/signup/magic-success", tr);
     }
     @Operation(summary = "리다이렉트용", description = "프론트엔드에서 구현 필요 X")
     @GetMapping("/login/magic")
     public RedirectView loginMagic(@RequestParam String token) {
         TokenResponseDto tr = authService.loginByToken(token);
-        String at = URLEncoder.encode(tr.accessToken(), StandardCharsets.UTF_8);
-        return new RedirectView("/login/magic-success#" + at);
+        return redirectWithFragment("/login/magic-success", tr);
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
@@ -12,6 +12,7 @@ import UMC.news.newsIntelligent.domain.member.repository.RevokedTokenRepository;
 import UMC.news.newsIntelligent.global.apiPayload.code.error.ErrorCode;
 import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
 import UMC.news.newsIntelligent.global.config.security.jwt.JwtTokenProvider;
+import UMC.news.newsIntelligent.global.utils.AuthUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,8 +34,8 @@ public class AuthService {
     private final OtpCodeRepository otpCodeRepository;
     private final MailService mailService;
     private final RevokedTokenRepository revokedTokenRepository;
-    private final NicknameService nicknameService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthUtils authUtils;
 
     /* 메일 발송 (공통) */
     public void sendCode(String email, OtpCode.Type type) {
@@ -72,46 +73,17 @@ public class AuthService {
 
     /* 회원가입 코드 검증 */
     public TokenResponseDto signupByCode(String email, String code) {
-        OtpCode otp = otpCodeRepository.findByEmailAndType(email, OtpCode.Type.SIGNUP)
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_400));
-        otp.validateUsable();
+        OtpCode otp = authUtils.getOtpCode(email, SIGNUP);
 
         if (!otp.getCode().equals(code))
             throw new CustomException(ErrorCode.OTP_WRONG);
 
-        Member member = memberRepository.findByEmail(email).orElse(null);
-        if (member == null) {
-            String nickname = nicknameService.proposeFromEmail(email);
-            member = memberRepository.save(
-                    Member.builder()
-                            .email(email)
-                            .notificationEmail(email)
-                            .nickname(nickname)
-                            .subscribeTopicAlert(true)
-                            .readTopicAlert(true)
-                            .dailyReportAlert(true)
-                            .isDeactivated(false)
-                            .build()
-            );
-        }
+        Member member = authUtils.saveAndReturnMember(email);
 
         otp.markVerified();
         otpCodeRepository.delete(otp);
 
-        String token = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), "ROLE_USER");
-        Date exp = jwtTokenProvider.getExpiration(token);
-        ZoneId KST = ZoneId.of("Asia/Seoul");
-        String expIsoKst = exp.toInstant()
-                .atZone(KST)
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-        member.updateLastLogin();
-        memberRepository.save(member);
-
-        return TokenResponseDto.builder()
-                .accessToken(token)
-                .expiresAt(expIsoKst)
-                .build();
+        return authUtils.generateToken(member);
     }
 
     /* 로그인 코드 검증 */
@@ -122,27 +94,14 @@ public class AuthService {
         if (member.isDeactivated())
             throw new CustomException(ErrorCode.MEMBER_ALREADY_DEACTIVATED);
 
-        OtpCode otpCode = otpCodeRepository.findByEmailAndType(email, LOGIN)
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_400));
-        otpCode.validateUsable();
+        OtpCode otpCode = authUtils.getOtpCode(email, LOGIN);
+
         if (!otpCode.getCode().equals(code))
             throw new CustomException(ErrorCode.OTP_WRONG);
 
-        String token = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), "ROLE_USER");
-
-        Date exp = jwtTokenProvider.getExpiration(token);
-        ZoneId KST = ZoneId.of("Asia/Seoul");
-        String expIsoKst = exp.toInstant()
-                .atZone(KST)
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-        member.updateLastLogin();
         otpCodeRepository.delete(otpCode);
 
-        return TokenResponseDto.builder()
-                .accessToken(token)
-                .expiresAt(expIsoKst)
-                .build();
+        return authUtils.generateToken(member);
     }
 
     /* 회원가입 매직링크 검증 */
@@ -150,7 +109,13 @@ public class AuthService {
         OtpCode otp = otpCodeRepository.findByTokenAndType(token, SIGNUP)
                 .orElseThrow(() ->  new CustomException(ErrorCode.BAD_REQUEST_400));
         otp.validateUsable();
-        return signupByCode(otp.getEmail(), otp.getCode());
+
+        Member member = authUtils.saveAndReturnMember(otp.getEmail());
+
+        otp.markVerified();
+        otpCodeRepository.delete(otp);
+
+        return authUtils.generateToken(member);
     }
 
     /* 로그인 매직링크 검증 */
@@ -158,7 +123,13 @@ public class AuthService {
         OtpCode otp = otpCodeRepository.findByTokenAndType(token, LOGIN)
                 .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_400));
         otp.validateUsable();
-        return loginByCode(otp.getEmail(), otp.getCode());
+
+        Member member = memberRepository.findByEmail(otp.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        if (member.isDeactivated()) throw new CustomException(ErrorCode.MEMBER_ALREADY_DEACTIVATED);
+
+        otpCodeRepository.delete(otp);
+        return authUtils.generateToken(member);
     }
 
     /* 로그아웃 */

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
@@ -71,7 +71,7 @@ public class AuthService {
     }
 
     /* 회원가입 코드 검증 */
-    public MemberResponseDto signupByCode(String email, String code) {
+    public TokenResponseDto signupByCode(String email, String code) {
         OtpCode otp = otpCodeRepository.findByEmailAndType(email, OtpCode.Type.SIGNUP)
                 .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_400));
         otp.validateUsable();
@@ -98,7 +98,20 @@ public class AuthService {
         otp.markVerified();
         otpCodeRepository.delete(otp);
 
-        return MemberResponseDto.from(member);
+        String token = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), "ROLE_USER");
+        Date exp = jwtTokenProvider.getExpiration(token);
+        ZoneId KST = ZoneId.of("Asia/Seoul");
+        String expIsoKst = exp.toInstant()
+                .atZone(KST)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        member.updateLastLogin();
+        memberRepository.save(member);
+
+        return TokenResponseDto.builder()
+                .accessToken(token)
+                .expiresAt(expIsoKst)
+                .build();
     }
 
     /* 로그인 코드 검증 */
@@ -133,7 +146,7 @@ public class AuthService {
     }
 
     /* 회원가입 매직링크 검증 */
-    public MemberResponseDto signupByToken(String token) {
+    public TokenResponseDto signupByToken(String token) {
         OtpCode otp = otpCodeRepository.findByTokenAndType(token, SIGNUP)
                 .orElseThrow(() ->  new CustomException(ErrorCode.BAD_REQUEST_400));
         otp.validateUsable();

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/AuthService.java
@@ -3,7 +3,6 @@ package UMC.news.newsIntelligent.domain.member.service;
 import UMC.news.newsIntelligent.domain.mail.entity.OtpCode;
 import UMC.news.newsIntelligent.domain.mail.repository.OtpCodeRepository;
 import UMC.news.newsIntelligent.domain.mail.service.MailService;
-import UMC.news.newsIntelligent.domain.member.dto.MemberResponseDto;
 import UMC.news.newsIntelligent.domain.member.entity.Member;
 import UMC.news.newsIntelligent.domain.member.entity.RevokedToken;
 import UMC.news.newsIntelligent.domain.member.repository.MemberRepository;
@@ -19,8 +18,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 import static UMC.news.newsIntelligent.domain.mail.entity.OtpCode.Type.LOGIN;
 import static UMC.news.newsIntelligent.domain.mail.entity.OtpCode.Type.SIGNUP;

--- a/src/main/java/UMC/news/newsIntelligent/global/utils/AuthUtils.java
+++ b/src/main/java/UMC/news/newsIntelligent/global/utils/AuthUtils.java
@@ -1,0 +1,78 @@
+package UMC.news.newsIntelligent.global.utils;
+
+import UMC.news.newsIntelligent.domain.mail.entity.OtpCode;
+import UMC.news.newsIntelligent.domain.mail.repository.OtpCodeRepository;
+import UMC.news.newsIntelligent.domain.member.dto.TokenResponseDto;
+import UMC.news.newsIntelligent.domain.member.entity.Member;
+import UMC.news.newsIntelligent.domain.member.repository.MemberRepository;
+import UMC.news.newsIntelligent.domain.member.service.NicknameService;
+import UMC.news.newsIntelligent.global.apiPayload.code.error.ErrorCode;
+import UMC.news.newsIntelligent.global.apiPayload.exception.CustomException;
+import UMC.news.newsIntelligent.global.config.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUtils {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final OtpCodeRepository otpCodeRepository;
+    private final NicknameService nicknameService;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    /* 만료시각 포매팅 */
+    public String toKstIso(Date exp) {
+        return exp.toInstant().atZone(KST).format(FORMATTER);
+    }
+
+    /* OTP 조회 */
+    public OtpCode getOtpCode(String email, OtpCode.Type type) {
+        OtpCode otp = otpCodeRepository.findByEmailAndType(email, OtpCode.Type.SIGNUP)
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST_400));
+        otp.validateUsable();
+
+        return otp;
+    }
+
+    /* 회원 아니면 새로 생성 */
+    public Member saveAndReturnMember(String email) {
+        return memberRepository.findByEmail(email).orElseGet(() -> {
+            String nickname = nicknameService.proposeFromEmail(email);
+            return memberRepository.save(
+                    Member.builder()
+                            .email(email)
+                            .notificationEmail(email)
+                            .nickname(nickname)
+                            .subscribeTopicAlert(true)
+                            .readTopicAlert(true)
+                            .dailyReportAlert(true)
+                            .isDeactivated(false)
+                            .build()
+            );
+        });
+    }
+
+    /* 토큰 발급 */
+    public TokenResponseDto generateToken(Member member) {
+        String token = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail(), "ROLE_USER");
+
+        String expIsoKst = toKstIso(jwtTokenProvider.getExpiration(token));
+
+        member.updateLastLogin();
+        memberRepository.save(member);
+
+        return TokenResponseDto.builder()
+                .accessToken(token)
+                .expiresAt(expIsoKst)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Issue 번호
- #98 

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- 회원가입 시에도 로그인과 동일하게 액세스 토큰 및 만료 시각 반환하도록 수정하였습니다.
- 이를 적용하면서 중복 코드를 별도 컴포넌트(`AuthUtils`)로 분리하였습니다.
- 매직링크에서 토큰 반환 방법을 기존 쿼리 스트링에서 fragment 방식으로 변경하였습니다. 프론트 고정 URL도 설정하였습니다.

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
- 회원가입 테스트 시 정상 동작합니다.
