### PR TITLE
fix: 토픽 조회 시 구독 여부 함께 반환하도록 수정

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
@@ -3,6 +3,7 @@ package UMC.news.newsIntelligent.domain.member.converter;
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Map;
@@ -39,5 +40,23 @@ public class MemberTopicConverter {
                         subscribedMap != null && subscribedMap.getOrDefault(t.getId(), false)
                 ))
                 .toList();
+    }
+
+    public static MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
+            Slice<Topic> slice,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap,
+            Map<Long, Boolean> subMap
+    ) {
+        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
+
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
+                ? topics.get(topics.size() - 1).id()
+                : null;
+
+        return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(slice.hasNext())
+                .topics(topics)
+                .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
@@ -12,7 +12,8 @@ public class MemberTopicConverter {
     // 단건 매핑
     public static MemberTopicResponseDTO.MemberTopicPreviewResDTO toPreviewResDTO(
             Topic topic,
-            TopicResponseDTO.ImageSource imageSource
+            TopicResponseDTO.ImageSource imageSource,
+            boolean isSub
     ) {
         return MemberTopicResponseDTO.MemberTopicPreviewResDTO.builder()
                 .id(topic.getId())
@@ -21,16 +22,22 @@ public class MemberTopicConverter {
                 .summaryTime(topic.getSummaryTime())
                 .imageUrl(topic.getImageUrl())
                 .imageSource(imageSource)
+                .isSub(isSub)
                 .build();
     }
 
     // 리스트 매핑
     public static List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> toPreviewResDTOList(
             List<Topic> topics,
-            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap
+            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap,
+            Map<Long, Boolean> subscribedMap
     ) {
         return topics.stream()
-                .map(t -> toPreviewResDTO(t, imageSourceMap.get(t.getId())))
+                .map(t -> toPreviewResDTO(
+                        t,
+                        imageSourceMap.get(t.getId()),
+                        subscribedMap != null && subscribedMap.getOrDefault(t.getId(), false)
+                ))
                 .toList();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/converter/MemberTopicConverter.java
@@ -1,6 +1,7 @@
 package UMC.news.newsIntelligent.domain.member.converter;
 
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
+import UMC.news.newsIntelligent.domain.member.entity.MemberTopic;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import org.springframework.data.domain.Slice;
@@ -10,36 +11,75 @@ import java.util.Map;
 
 public class MemberTopicConverter {
 
-    // 단건 매핑
     public static MemberTopicResponseDTO.MemberTopicPreviewResDTO toPreviewResDTO(
-            Topic topic,
-            TopicResponseDTO.ImageSource imageSource,
-            boolean isSub
+            MemberTopic mt, TopicResponseDTO.ImageSource imageSource
+    ) {
+        Topic t = mt.getTopic();
+        return MemberTopicResponseDTO.MemberTopicPreviewResDTO.builder()
+                .id(t.getId())
+                .topicName(t.getTopicName())
+                .aiSummary(t.getAiSummary())
+                .summaryTime(t.getSummaryTime())
+                .imageUrl(t.getImageUrl())
+                .imageSource(imageSource)
+                .isSub(Boolean.TRUE.equals(mt.getIsSubscribe()))
+                .build();
+    }
+
+    public static MemberTopicResponseDTO.MemberTopicPreviewResDTO toPreviewResDTO(
+            Topic t, TopicResponseDTO.ImageSource imageSource, boolean isSub
     ) {
         return MemberTopicResponseDTO.MemberTopicPreviewResDTO.builder()
-                .id(topic.getId())
-                .topicName(topic.getTopicName())
-                .aiSummary(topic.getAiSummary())
-                .summaryTime(topic.getSummaryTime())
-                .imageUrl(topic.getImageUrl())
+                .id(t.getId())
+                .topicName(t.getTopicName())
+                .aiSummary(t.getAiSummary())
+                .summaryTime(t.getSummaryTime())
+                .imageUrl(t.getImageUrl())
                 .imageSource(imageSource)
                 .isSub(isSub)
                 .build();
     }
 
-    // 리스트 매핑
-    public static List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> toPreviewResDTOList(
-            List<Topic> topics,
-            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap,
-            Map<Long, Boolean> subscribedMap
+    private static List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> mapFromMemberTopic(
+            List<MemberTopic> list, Map<Long, TopicResponseDTO.ImageSource> srcMap
     ) {
-        return topics.stream()
+        return list.stream()
+                .map(mt -> {
+                    Long tid = mt.getTopic().getId();
+                    return toPreviewResDTO(mt, srcMap.get(tid));
+                })
+                .toList();
+    }
+
+    private static List<MemberTopicResponseDTO.MemberTopicPreviewResDTO> mapFromTopic(
+            List<Topic> list,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap,
+            Map<Long, Boolean> subMap
+    ) {
+        return list.stream()
                 .map(t -> toPreviewResDTO(
                         t,
-                        imageSourceMap.get(t.getId()),
-                        subscribedMap != null && subscribedMap.getOrDefault(t.getId(), false)
+                        srcMap.get(t.getId()),
+                        subMap != null && subMap.getOrDefault(t.getId(), false)
                 ))
                 .toList();
+    }
+
+    public static MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
+            Slice<MemberTopic> slice,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap
+    ) {
+        var topics = mapFromMemberTopic(slice.getContent(), srcMap);
+
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
+                ? topics.get(topics.size() - 1).id()
+                : null;
+
+        return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(slice.hasNext())
+                .topics(topics)
+                .build();
     }
 
     public static MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
@@ -47,7 +87,7 @@ public class MemberTopicConverter {
             Map<Long, TopicResponseDTO.ImageSource> srcMap,
             Map<Long, Boolean> subMap
     ) {
-        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
+        var topics = mapFromTopic(slice.getContent(), srcMap, subMap);
 
         Long nextCursor = (slice.hasNext() && !topics.isEmpty())
                 ? topics.get(topics.size() - 1).id()

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberTopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/dto/MemberTopicResponseDTO.java
@@ -17,7 +17,8 @@ public class MemberTopicResponseDTO {
             String aiSummary,
             LocalDateTime summaryTime,
             String imageUrl,
-            TopicResponseDTO.ImageSource imageSource
+            TopicResponseDTO.ImageSource imageSource,
+            boolean isSub
     ) {}
 
     @Builder

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
@@ -16,43 +16,20 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> {
 
-    // memberTopic 에서 isRead = true 인 것 중, topicName 을 기준으로 keyword 검색 & 커서 페이지네이션 구현
     @Query("""
-    SELECT mt.topic FROM MemberTopic mt
-    WHERE mt.member.id = :memberId
-      AND mt.isRead = true
-      AND (:keyword IS NULL OR LOWER(mt.topic.topicName) LIKE CONCAT('%', LOWER(:keyword), '%'))
-      AND (:cursor IS NULL OR mt.topic.id < :cursor)
-    ORDER BY mt.topic.id DESC
-""")
-    Slice<Topic> searchReadTopicsByKeyword(
+        select mt
+          from MemberTopic mt
+          join fetch mt.topic t
+         where mt.member.id = :memberId
+           and mt.isRead = true
+           and (:cursor is null or t.id < :cursor)
+         order by t.id desc
+    """)
+    Slice<MemberTopic> getReadWithTopic(
             @Param("memberId") Long memberId,
-            @Param("keyword") String keyword,
             @Param("cursor") Long cursor,
             Pageable pageable
     );
-
-    @Query("""
-    select t
-    from MemberTopic mt
-    join fetch mt.topic t
-    where mt.member.id = :memberId
-      and mt.isRead = true
-      and (:cursor is null or t.id < :cursor)
-    order by t.id desc
-    """)
-    Slice<Topic> getReadTopicsByMemberId(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
-
-    @Query("""
-    select t
-    from MemberTopic mt
-    join fetch mt.topic t
-    where mt.member.id = :memberId
-      and mt.isSubscribe = true
-      and (:cursor is null or t.id < :cursor)
-    order by t.id desc
-    """)
-    Slice<Topic> getSubscriptionTopicsByMemberId(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 
     Optional<MemberTopic> findByMemberIdAndTopicId(Long memberId, Long topicId);
 
@@ -77,10 +54,11 @@ public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> 
     // 해당 토픽을 읽은 멤버 조회
     @Query("""
         SELECT mt.member.id
-        FROM MemberTopic mt
-        WHERE mt.topic.id IN :topicId AND mt.isRead = true
+          FROM MemberTopic mt
+         WHERE mt.topic.id = :topicId AND mt.isRead = true
     """)
-    List<Long> findReadMemberIdsByTopicId(Long topicId);
+    List<Long> findReadMemberIdsByTopicId(@Param("topicId") Long topicId);
+
 
     @Query("""
     select mt.topic.id
@@ -91,6 +69,40 @@ public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> 
 """)
     List<Long> findSubscribedTopicIdsByMemberAndTopicIds(@Param("memberId") Long memberId,
                                                          @Param("topicIds") List<Long> topicIds);
+
+    // 구독 목록
+    @Query("""
+        select mt
+          from MemberTopic mt
+          join fetch mt.topic t
+         where mt.member.id = :memberId
+           and mt.isSubscribe = true
+           and (:cursor is null or t.id < :cursor)
+         order by t.id desc
+    """)
+    Slice<MemberTopic> findSubscribedWithTopic(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    // 읽은 목록
+    @Query("""
+        select mt
+          from MemberTopic mt
+          join fetch mt.topic t
+         where mt.member.id = :memberId
+           and mt.isRead = true
+           and (:keyword is null or lower(t.topicName) like concat('%', lower(:keyword), '%'))
+           and (:cursor is null or t.id < :cursor)
+         order by t.id desc
+    """)
+    Slice<MemberTopic> searchReadWithTopic(
+            @Param("memberId") Long memberId,
+            @Param("keyword") String keyword,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
 
     boolean existsByMemberIdAndTopicIdAndIsSubscribeTrue(Long memberId, Long topicId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
@@ -77,4 +77,16 @@ public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> 
         WHERE mt.topic.id IN :topicId AND mt.isRead = true
     """)
     List<Long> findReadMemberIdsByTopicId(Long topicId);
+
+    @Query("""
+    select mt.topic.id
+      from MemberTopic mt
+     where mt.member.id = :memberId
+       and mt.isSubscribe = true
+       and mt.topic.id in :topicIds
+""")
+    List<Long> findSubscribedTopicIdsByMemberAndTopicIds(@Param("memberId") Long memberId,
+                                                         @Param("topicIds") List<Long> topicIds);
+
+    boolean existsByMemberIdAndTopicIdAndIsSubscribeTrue(Long memberId, Long topicId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/repository/MemberTopicRepository.java
@@ -33,21 +33,25 @@ public interface MemberTopicRepository extends JpaRepository<MemberTopic, Long> 
     );
 
     @Query("""
-    SELECT mt.topic FROM MemberTopic mt
-    WHERE mt.member.id = :memberId
-      AND mt.isRead = true
-      AND (:cursor IS NULL OR mt.topic.id < :cursor)
-    ORDER BY mt.topic.id DESC
-""")
+    select t
+    from MemberTopic mt
+    join fetch mt.topic t
+    where mt.member.id = :memberId
+      and mt.isRead = true
+      and (:cursor is null or t.id < :cursor)
+    order by t.id desc
+    """)
     Slice<Topic> getReadTopicsByMemberId(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 
     @Query("""
-    SELECT mt.topic FROM MemberTopic mt
-    WHERE mt.member.id = :memberId
-      AND mt.isSubscribe = true
-      AND (:cursor IS NULL OR mt.topic.id < :cursor)
-    ORDER BY mt.topic.id DESC
-""")
+    select t
+    from MemberTopic mt
+    join fetch mt.topic t
+    where mt.member.id = :memberId
+      and mt.isSubscribe = true
+      and (:cursor is null or t.id < :cursor)
+    order by t.id desc
+    """)
     Slice<Topic> getSubscriptionTopicsByMemberId(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 
     Optional<MemberTopic> findByMemberIdAndTopicId(Long memberId, Long topicId);

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryService.java
@@ -1,10 +1,16 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Map;
 
 public interface MemberTopicQueryService {
 
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO searchReadTopics(String keyword, Long cursor, int size, Long memberId);
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO getReadTopics(Long cursor, int size, Long memberId);
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO getSubscriptionTopics(Long cursor, int size, Long memberId);
+    Map<Long, Boolean> buildSubscribedMap(Long memberId, Slice<Topic> slice);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryService.java
@@ -12,5 +12,4 @@ public interface MemberTopicQueryService {
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO searchReadTopics(String keyword, Long cursor, int size, Long memberId);
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO getReadTopics(Long cursor, int size, Long memberId);
     MemberTopicResponseDTO.MemberTopicPreviewListResDTO getSubscriptionTopics(Long cursor, int size, Long memberId);
-    Map<Long, Boolean> buildSubscribedMap(Long memberId, Slice<Topic> slice);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -1,8 +1,8 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
-import UMC.news.newsIntelligent.domain.member.converter.MemberTopicConverter;
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
 import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
+import UMC.news.newsIntelligent.domain.member.support.TopicQueryUtils;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
 import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 
+import static UMC.news.newsIntelligent.domain.member.converter.MemberTopicConverter.toPreviewList;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,52 +28,67 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
     private final NewsRepository newsRepository;
 
     @Override
-    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO searchReadTopics(String keyword, Long cursor, int size, Long memberId) {
+    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO searchReadTopics(
+            String keyword, Long cursor, int size, Long memberId
+    ) {
         cursor = normalizeCursor(cursor);
         size = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice = memberTopicRepository.searchReadTopicsByKeyword(memberId, keyword, cursor, pageable);
+        Slice<Topic> topicSlice =
+                memberTopicRepository.searchReadTopicsByKeyword(memberId, keyword, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        Map<Long, Boolean> subMap =
+                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
+
         return toPreviewList(topicSlice, srcMap, subMap);
     }
 
     @Override
-    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO getReadTopics(Long cursor, int size, Long memberId) {
+    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO getReadTopics(
+            Long cursor, int size, Long memberId
+    ) {
         cursor = normalizeCursor(cursor);
         size = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice = memberTopicRepository.getReadTopicsByMemberId(memberId, cursor, pageable);
+        Slice<Topic> topicSlice =
+                memberTopicRepository.getReadTopicsByMemberId(memberId, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        Map<Long, Boolean> subMap =
+                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
+
         return toPreviewList(topicSlice, srcMap, subMap);
     }
 
     @Override
-    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO getSubscriptionTopics(Long cursor, int size, Long memberId) {
+    public MemberTopicResponseDTO.MemberTopicPreviewListResDTO getSubscriptionTopics(
+            Long cursor, int size, Long memberId
+    ) {
         cursor = normalizeCursor(cursor);
         size = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice = memberTopicRepository.getSubscriptionTopicsByMemberId(memberId, cursor, pageable);
+        Slice<Topic> topicSlice =
+                memberTopicRepository.getSubscriptionTopicsByMemberId(memberId, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        Map<Long, Boolean> subMap =
+                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
+
         return toPreviewList(topicSlice, srcMap, subMap);
     }
 
-    // 해당 페이지 기사들 한 번에 조회 -> Map
+
     private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromSlice(Slice<Topic> slice) {
         List<Long> topicIds = slice.getContent().stream()
-                .map(Topic::getId).toList();
+                .map(Topic::getId)
+                .toList();
 
         if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
 
-        // OldestPerTopicProjection: (topicId, press, title) 를 가진 프로젝션
         List<OldestPerTopicProjection> oldestList = newsRepository.findOldestPerTopic(topicIds);
 
         return oldestList.stream().collect(
@@ -86,49 +103,11 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         );
     }
 
-    private MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
-            Slice<Topic> slice,
-            Map<Long, TopicResponseDTO.ImageSource> srcMap,
-            Map<Long, Boolean> subMap
-    ) {
-        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
-
-        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
-                ? topics.get(topics.size() - 1).id()
-                : null;
-
-        return MemberTopicResponseDTO.MemberTopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(slice.hasNext())
-                .topics(topics)
-                .build();
-    }
-
-    // 로그인 유저 구독여부 매핑
-    public Map<Long, Boolean> buildSubscribedMap(Long memberId, Slice<Topic> slice) {
-        List<Long> topicIds = slice.getContent().stream().map(Topic::getId).toList();
-        if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
-
-        if (memberId == null) {
-            // 비로그인의 경우 전부 false
-            return java.util.Collections.emptyMap();
-        }
-
-        List<Long> subscribed = memberTopicRepository
-                .findSubscribedTopicIdsByMemberAndTopicIds(memberId, topicIds);
-
-        Map<Long, Boolean> map = new java.util.HashMap<>();
-        for (Long id : subscribed) map.put(id, true);
-        return map;
-    }
-
     private Long normalizeCursor(Long cursor) {
         return (cursor == null || cursor == 0) ? Long.MAX_VALUE : cursor;
     }
 
-    // 요청 사이즈가 1보다 작으면 기본값 10, 10보다 크면 최대값 10으로 제한
     private int normalizeSize(int size) {
         return (size < 1 || size > 10) ? 10 : size;
     }
-
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package UMC.news.newsIntelligent.domain.member.service;
 
+import UMC.news.newsIntelligent.domain.member.converter.MemberTopicConverter;
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
+import UMC.news.newsIntelligent.domain.member.entity.MemberTopic;
 import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
 import UMC.news.newsIntelligent.domain.member.support.TopicQueryUtils;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
@@ -35,14 +37,11 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         size = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice =
-                memberTopicRepository.searchReadTopicsByKeyword(memberId, keyword, cursor, pageable);
+        Slice<MemberTopic> slice =
+                memberTopicRepository.searchReadWithTopic(memberId, keyword, cursor, pageable);
 
-        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap =
-                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
-
-        return toPreviewList(topicSlice, srcMap, subMap);
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromMtSlice(slice);
+        return MemberTopicConverter.toPreviewList(slice, srcMap);
     }
 
     @Override
@@ -50,17 +49,14 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
             Long cursor, int size, Long memberId
     ) {
         cursor = normalizeCursor(cursor);
-        size = normalizeSize(size);
+        size  = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice =
-                memberTopicRepository.getReadTopicsByMemberId(memberId, cursor, pageable);
+        Slice<MemberTopic> slice =
+                memberTopicRepository.getReadWithTopic(memberId, cursor, pageable);
 
-        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap =
-                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
-
-        return toPreviewList(topicSlice, srcMap, subMap);
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromMtSlice(slice);
+        return MemberTopicConverter.toPreviewList(slice, srcMap);
     }
 
     @Override
@@ -68,29 +64,23 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
             Long cursor, int size, Long memberId
     ) {
         cursor = normalizeCursor(cursor);
-        size = normalizeSize(size);
+        size  = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Topic> topicSlice =
-                memberTopicRepository.getSubscriptionTopicsByMemberId(memberId, cursor, pageable);
+        Slice<MemberTopic> slice =
+                memberTopicRepository.findSubscribedWithTopic(memberId, cursor, pageable);
 
-        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap =
-                TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
-
-        return toPreviewList(topicSlice, srcMap, subMap);
+        Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromMtSlice(slice);
+        return MemberTopicConverter.toPreviewList(slice, srcMap);
     }
 
-
-    private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromSlice(Slice<Topic> slice) {
+    private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromMtSlice(Slice<MemberTopic> slice) {
         List<Long> topicIds = slice.getContent().stream()
-                .map(Topic::getId)
+                .map(mt -> mt.getTopic().getId())
                 .toList();
-
         if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
 
         List<OldestPerTopicProjection> oldestList = newsRepository.findOldestPerTopic(topicIds);
-
         return oldestList.stream().collect(
                 java.util.stream.Collectors.toMap(
                         OldestPerTopicProjection::getTopicId,

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -34,7 +34,8 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Slice<Topic> topicSlice = memberTopicRepository.searchReadTopicsByKeyword(memberId, keyword, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        return toPreviewList(topicSlice, srcMap);
+        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        return toPreviewList(topicSlice, srcMap, subMap);
     }
 
     @Override
@@ -46,7 +47,8 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Slice<Topic> topicSlice = memberTopicRepository.getReadTopicsByMemberId(memberId, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        return toPreviewList(topicSlice, srcMap);
+        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        return toPreviewList(topicSlice, srcMap, subMap);
     }
 
     @Override
@@ -58,7 +60,8 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
         Slice<Topic> topicSlice = memberTopicRepository.getSubscriptionTopicsByMemberId(memberId, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        return toPreviewList(topicSlice, srcMap);
+        Map<Long, Boolean> subMap = buildSubscribedMap(memberId, topicSlice);
+        return toPreviewList(topicSlice, srcMap, subMap);
     }
 
     // 해당 페이지 기사들 한 번에 조회 -> Map
@@ -85,9 +88,10 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
 
     private MemberTopicResponseDTO.MemberTopicPreviewListResDTO toPreviewList(
             Slice<Topic> slice,
-            Map<Long, TopicResponseDTO.ImageSource> srcMap
+            Map<Long, TopicResponseDTO.ImageSource> srcMap,
+            Map<Long, Boolean> subMap
     ) {
-        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap);
+        var topics = MemberTopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
 
         Long nextCursor = (slice.hasNext() && !topics.isEmpty())
                 ? topics.get(topics.size() - 1).id()
@@ -98,6 +102,24 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
                 .hasNext(slice.hasNext())
                 .topics(topics)
                 .build();
+    }
+
+    // 로그인 유저 구독여부 매핑
+    public Map<Long, Boolean> buildSubscribedMap(Long memberId, Slice<Topic> slice) {
+        List<Long> topicIds = slice.getContent().stream().map(Topic::getId).toList();
+        if (topicIds.isEmpty()) return java.util.Collections.emptyMap();
+
+        if (memberId == null) {
+            // 비로그인의 경우 전부 false
+            return java.util.Collections.emptyMap();
+        }
+
+        List<Long> subscribed = memberTopicRepository
+                .findSubscribedTopicIdsByMemberAndTopicIds(memberId, topicIds);
+
+        Map<Long, Boolean> map = new java.util.HashMap<>();
+        for (Long id : subscribed) map.put(id, true);
+        return map;
     }
 
     private Long normalizeCursor(Long cursor) {

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/support/TopicQueryUtils.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/support/TopicQueryUtils.java
@@ -1,0 +1,44 @@
+package UMC.news.newsIntelligent.domain.member.support;
+
+import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
+import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import org.springframework.data.domain.Slice;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 순수 유틸리티: 스프링 빈/필드 의존 없음.
+ * 필요한 리포지토리는 메서드 파라미터로 주입해서 사용.
+ */
+public final class TopicQueryUtils {
+
+    private TopicQueryUtils() { }
+
+    public static Map<Long, Boolean> buildSubscribedMap(Long memberId,
+                                                        Slice<Topic> slice,
+                                                        MemberTopicRepository memberTopicRepository) {
+        List<Long> topicIds = slice.getContent().stream()
+                .map(Topic::getId)
+                .toList();
+        return buildSubscribedMap(memberId, topicIds, memberTopicRepository);
+    }
+
+    public static Map<Long, Boolean> buildSubscribedMap(Long memberId,
+                                                        List<Long> topicIds,
+                                                        MemberTopicRepository memberTopicRepository) {
+        if (topicIds == null || topicIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        // 비로그인: 전부 false
+        if (memberId == null) {
+            return topicIds.stream().collect(Collectors.toMap(id -> id, id -> false));
+        }
+
+        List<Long> subscribedIds =
+                memberTopicRepository.findSubscribedTopicIdsByMemberAndTopicIds(memberId, topicIds);
+        Set<Long> subscribedSet = new HashSet<>(subscribedIds);
+
+        return topicIds.stream().collect(Collectors.toMap(id -> id, subscribedSet::contains));
+    }
+}

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/controller/NewsController.java
@@ -6,12 +6,16 @@ import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.service.query.TopicQueryService;
 import UMC.news.newsIntelligent.global.apiPayload.CustomResponse;
 import UMC.news.newsIntelligent.global.apiPayload.code.success.SuccessCode;
+import UMC.news.newsIntelligent.global.config.security.PrincipalUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.attribute.UserPrincipal;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,8 +31,12 @@ public class NewsController {
             @ApiResponse(responseCode = "200", description = "토픽 상세 페이지 조회 성공")
     })
     @GetMapping("/{topicId}")
-    public CustomResponse<TopicResponseDTO.TopicPreviewResDTO> getTopicDetails(@PathVariable Long topicId){
-        TopicResponseDTO.TopicPreviewResDTO topicDetailsDTO = topicQueryService.getTopicById(topicId);
+    public CustomResponse<TopicResponseDTO.TopicPreviewResDTO> getTopicDetails(
+            @PathVariable Long topicId,
+            @AuthenticationPrincipal PrincipalUserDetails principal
+            ){
+        Long memberId = (principal == null) ? null : principal.getMemberId();
+        TopicResponseDTO.TopicPreviewResDTO topicDetailsDTO = topicQueryService.getTopicById(topicId, memberId);
         return CustomResponse.onSuccess(SuccessCode.GET_TOPIC, topicDetailsDTO);
     }
 
@@ -51,8 +59,11 @@ public class NewsController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토픽 출처 기사 목록 조회 성공")
     })
     @GetMapping("/latest")
-    public CustomResponse<NewsResponseDTO.TopicQualifiedListResDTO> getLatestTopic() {
-        NewsResponseDTO.TopicQualifiedListResDTO latestTopicNews = newsQueryServiceImpl.getLatestTopicNews();
+    public CustomResponse<NewsResponseDTO.TopicQualifiedListResDTO> getLatestTopic(
+            @AuthenticationPrincipal PrincipalUserDetails principal
+    ) {
+        Long memberId = (principal == null) ? null : principal.getMemberId();
+        NewsResponseDTO.TopicQualifiedListResDTO latestTopicNews = newsQueryServiceImpl.getLatestTopicNews(memberId);
         return CustomResponse.onSuccess(SuccessCode.GET_LATEST_TOPIC, latestTopicNews);
     }
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/converter/NewsConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/converter/NewsConverter.java
@@ -53,6 +53,7 @@ public final class NewsConverter {
     public static NewsResponseDTO.TopicQualifiedItemResDTO toTopicQualifiedItem(
             Topic topic,
             NewsResponseDTO.ImageSource imageSource,
+            boolean isSub,
             List<NewsResponseDTO.NewsRelatedArticleDto> related
     ) {
         return NewsResponseDTO.TopicQualifiedItemResDTO.builder()
@@ -62,6 +63,7 @@ public final class NewsConverter {
                 .imageUrl(topic.getImageUrl())
                 .summaryTime(topic.getSummaryTime())
                 .imageSource(imageSource)
+                .isSub(isSub)
                 .relatedArticles(related)
                 .build();
     }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/dto/NewsResponseDTO.java
@@ -50,6 +50,7 @@ public class NewsResponseDTO {
             String imageUrl,
             LocalDateTime summaryTime,
             ImageSource imageSource,
+            boolean isSub,
             List<NewsRelatedArticleDto> relatedArticles
     ) {}
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryService.java
@@ -7,5 +7,5 @@ public interface NewsQueryService {
 
     NewsResponseDTO.NewsResDTO getRelatedNews(Long topicId, Long lastId, int size);
 
-    NewsResponseDTO.TopicQualifiedListResDTO getLatestTopicNews();
+    NewsResponseDTO.TopicQualifiedListResDTO getLatestTopicNews(Long memberId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package UMC.news.newsIntelligent.domain.news.service;
 
+import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
 import UMC.news.newsIntelligent.domain.news.converter.NewsConverter;
 import UMC.news.newsIntelligent.domain.news.dto.NewsResponseDTO;
 //import UMC.news.newsIntelligent.domain.news.entity.News;
@@ -36,6 +37,7 @@ public class NewsQueryServiceImpl implements NewsQueryService{
     private final PressLogoRepository pressLogoRepository;
     private final LatestCorrectionRepository latestCorrectionRepository;
     private final LatestCorrectionItemRepository lcItemRepository;
+    private final MemberTopicRepository memberTopicRepository;
 
     // 연관 기사 목록
     @Override
@@ -61,8 +63,8 @@ public class NewsQueryServiceImpl implements NewsQueryService{
 
     @Override
     @Transactional(readOnly = true)
-    public NewsResponseDTO.TopicQualifiedListResDTO getLatestTopicNews() {
-        // 1) 최신수정보도 중 "토픽 기사 수 ≥ 3"인 것 3건
+    public NewsResponseDTO.TopicQualifiedListResDTO getLatestTopicNews(Long memberId) {
+        // 최신수정보도 중 "토픽 기사 수 ≥ 3"인 것 4건
         var top3Page = org.springframework.data.domain.PageRequest.of(0, 4);
         var lcs = latestCorrectionRepository.findRecentWhoseTopicHasAtLeastNews(3, top3Page);
         if (lcs.isEmpty()) {
@@ -75,12 +77,12 @@ public class NewsQueryServiceImpl implements NewsQueryService{
             var topic   = lc.getTopic();
             Long topicId = topic.getId();
 
-            // 2) 자격 뉴스(이번 run에서 잡힌 것들) 최신순으로 최대 3개
+            // 자격 뉴스(이번 run에서 잡힌 것들) 최신순으로 최대 3개
             var three = org.springframework.data.domain.PageRequest.of(0, 3);
             List<News> qualified = lcItemRepository
                     .findQualifiedNewsByLatestCorrectionId(lc.getId(), three);
 
-            // 3) 부족하면 같은 토픽의 다른 최신 뉴스로 채우기 (자격뉴스 제외)
+            // 부족하면 같은 토픽의 다른 최신 뉴스로 채우기 (자격뉴스 제외)
             List<Long> excludeIds = qualified.stream().map(News::getId).toList();
             if (qualified.size() < 3) {
                 int need = 3 - qualified.size();
@@ -96,12 +98,12 @@ public class NewsQueryServiceImpl implements NewsQueryService{
                 }
             }
 
-            // 4) 최대 3개만 사용하여 DTO 변환
+            // 최대 3개만 사용하여 DTO 변환
             List<News> top3 = (qualified.size() > 3) ? qualified.subList(0, 3) : qualified;
             List<NewsResponseDTO.NewsRelatedArticleDto> related =
                     NewsConverter.toRelatedDtos(top3);
 
-            // 5) 출처 기사 (가장 오래된 기사 + id DESC)
+            // 출처 기사 (가장 오래된 기사 + id DESC)
             var sourceOpt = newsRepository.findFirstByTopicIdOrderByPublishDateAscIdDesc(topicId);
             NewsResponseDTO.ImageSource imageSource = sourceOpt
                     .map(n -> NewsResponseDTO.ImageSource.builder()
@@ -110,12 +112,18 @@ public class NewsQueryServiceImpl implements NewsQueryService{
                             .build())
                     .orElse(null);
 
-            // 6) 단건 아이템 DTO
-            var item = NewsConverter.toTopicQualifiedItem(topic, imageSource, related);
+            boolean isSub = false;
+            if (memberId != null) {
+                isSub = memberTopicRepository
+                        .existsByMemberIdAndTopicIdAndIsSubscribeTrue(memberId, topicId);
+            }
+
+            // 단건 아이템 DTO
+            var item = NewsConverter.toTopicQualifiedItem(topic, imageSource, isSub, related);
             items.add(item);
         }
 
-        // 7) 3건 묶어서 반환
+        // 3건 묶어서 반환
         return NewsResponseDTO.TopicQualifiedListResDTO.builder()
                 .items(items)
                 .build();

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/service/NewsQueryServiceImpl.java
@@ -32,7 +32,6 @@ public class NewsQueryServiceImpl implements NewsQueryService{
     private static final int MAX_PAGE_SIZE = 20;
     private static final String DEFAULT_LOGO = null; // 기본 로고
 
-    private final TopicRepository topicRepository;
     private final NewsRepository newsRepository;
     private final PressLogoRepository pressLogoRepository;
     private final LatestCorrectionRepository latestCorrectionRepository;

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/controller/TopicController.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/controller/TopicController.java
@@ -43,9 +43,11 @@ public class TopicController {
     public CustomResponse<TopicResponseDTO.TopicPreviewListResDTO> searchTopics(
             @RequestParam String keyword,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") @Max(10) int size
+            @RequestParam(defaultValue = "10") @Max(10) int size,
+            @AuthenticationPrincipal PrincipalUserDetails principal
     ) {
-        TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.searchTopics(keyword, cursor, size);
+        Long memberId = (principal == null) ? null : principal.getMemberId();
+        TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.searchTopics(keyword, cursor, size, memberId);
 
         return CustomResponse.onSuccess(topicResDTO);
     }
@@ -59,9 +61,11 @@ public class TopicController {
     @GetMapping("/home")
     public CustomResponse<TopicResponseDTO.TopicPreviewListResDTO> getTopics(
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") @Max(10) int size
+            @RequestParam(defaultValue = "10") @Max(10) int size,
+            @AuthenticationPrincipal PrincipalUserDetails principal
     ) {
-        TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.getTopicList(cursor, size);
+        Long memberId = (principal == null) ? null : principal.getMemberId();
+        TopicResponseDTO.TopicPreviewListResDTO topicResDTO = topicQueryService.getTopicList(cursor, size, memberId);
 
         return CustomResponse.onSuccess(topicResDTO);
     }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
@@ -11,7 +11,8 @@ public class TopicConverter {
     // 단건 매핑
     public static TopicResponseDTO.TopicPreviewResDTO toPreviewResDTO(
             Topic topic,
-            TopicResponseDTO.ImageSource imageSource
+            TopicResponseDTO.ImageSource imageSource,
+            boolean isSub
     ) {
         return TopicResponseDTO.TopicPreviewResDTO.builder()
                 .id(topic.getId())
@@ -20,16 +21,22 @@ public class TopicConverter {
                 .summaryTime(topic.getSummaryTime())
                 .imageUrl(topic.getImageUrl())
                 .imageSource(imageSource)
+                .isSub(isSub)
                 .build();
     }
 
     // 리스트 매핑
     public static List<TopicResponseDTO.TopicPreviewResDTO> toPreviewResDTOList(
             List<Topic> topics,
-            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap
+            Map<Long, TopicResponseDTO.ImageSource> imageSourceMap,
+            Map<Long, Boolean> subscribedMap
     ) {
         return topics.stream()
-                .map(t -> toPreviewResDTO(t, imageSourceMap.get(t.getId())))
+                .map(t -> toPreviewResDTO(
+                        t,
+                        imageSourceMap.get(t.getId()),
+                        subscribedMap.getOrDefault(t.getId(), false)
+                ))
                 .toList();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
@@ -36,7 +36,7 @@ public class TopicConverter {
                 .map(t -> toPreviewResDTO(
                         t,
                         imageSourceMap.get(t.getId()),
-                        subscribedMap.getOrDefault(t.getId(), false)
+                        (subscribedMap != null) && subscribedMap.getOrDefault(t.getId(), false)
                 ))
                 .toList();
     }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/converter/TopicConverter.java
@@ -2,6 +2,7 @@ package UMC.news.newsIntelligent.domain.topic.converter;
 
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Map;
@@ -38,5 +39,24 @@ public class TopicConverter {
                         subscribedMap.getOrDefault(t.getId(), false)
                 ))
                 .toList();
+    }
+
+    public static TopicResponseDTO.TopicPreviewListResDTO mapSliceToPreviewListDTO(
+            Slice<Topic> slice,
+            Map<Long, TopicResponseDTO.ImageSource> srcMap,
+            Map<Long, Boolean> subMap
+    ) {
+        List<TopicResponseDTO.TopicPreviewResDTO> topics =
+                TopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
+
+        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
+                ? topics.get(topics.size() - 1).id()
+                : null;
+
+        return TopicResponseDTO.TopicPreviewListResDTO.builder()
+                .cursor(nextCursor)
+                .hasNext(slice.hasNext())
+                .topics(topics)
+                .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
@@ -16,7 +16,8 @@ public class TopicResponseDTO {
             String aiSummary,
             LocalDateTime summaryTime,
             String imageUrl,
-            ImageSource imageSource
+            ImageSource imageSource,
+            boolean isSub
     ) {}
 
     @Builder

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryService.java
@@ -4,9 +4,9 @@ import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 
 public interface TopicQueryService {
-    TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size);
+    TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size, Long memberId);
 
-    TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size);
+    TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size, Long memberId);
 
-    TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId);
+    TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId, Long memberId);
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -1,11 +1,10 @@
 package UMC.news.newsIntelligent.domain.topic.service.query;
 
 import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
-import UMC.news.newsIntelligent.domain.member.service.MemberTopicQueryService;
+import UMC.news.newsIntelligent.domain.member.support.TopicQueryUtils;
 import UMC.news.newsIntelligent.domain.news.entity.News;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
 import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
-import UMC.news.newsIntelligent.domain.topic.converter.TopicConverter;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
 import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import UMC.news.newsIntelligent.domain.topic.repository.TopicRepository;
@@ -22,6 +21,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static UMC.news.newsIntelligent.domain.topic.converter.TopicConverter.mapSliceToPreviewListDTO;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,9 +30,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
     private final TopicRepository topicRepository;
     private final NewsRepository newsRepository;
-    private final MemberTopicQueryService memberTopicQueryService;
     private final MemberTopicRepository memberTopicRepository;
-
 
     @Override
     public TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size, Long memberId) {
@@ -42,7 +41,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Slice<Topic> topicSlice = topicRepository.findByKeywordAndCursor(keyword, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        Map<Long, Boolean> subMap = memberTopicQueryService.buildSubscribedMap(memberId, topicSlice);
+        Map<Long, Boolean> subMap = TopicQueryUtils.buildSubscribedMap(memberId, topicSlice, memberTopicRepository);
 
         return mapSliceToPreviewListDTO(topicSlice, srcMap, subMap);
     }
@@ -75,7 +74,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
         Slice<Topic> slice = topicRepository.findByCursorOrderBySummaryTimeDesc(cursorTime, cursorId, pageable);
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(slice);
-        Map<Long, Boolean> subMap = memberTopicQueryService.buildSubscribedMap(memberId, slice);
+        Map<Long, Boolean> subMap = TopicQueryUtils.buildSubscribedMap(memberId, slice, memberTopicRepository);
 
         return mapSliceToPreviewListDTO(slice, srcMap, subMap);
     }
@@ -130,24 +129,5 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                         (a, b) -> a
                 )
         );
-    }
-
-    private TopicResponseDTO.TopicPreviewListResDTO mapSliceToPreviewListDTO(
-            Slice<Topic> slice,
-            Map<Long, TopicResponseDTO.ImageSource> srcMap,
-            Map<Long, Boolean> subMap
-    ) {
-        List<TopicResponseDTO.TopicPreviewResDTO> topics =
-                TopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
-
-        Long nextCursor = (slice.hasNext() && !topics.isEmpty())
-                ? topics.get(topics.size() - 1).id()
-                : null;
-
-        return TopicResponseDTO.TopicPreviewListResDTO.builder()
-                .cursor(nextCursor)
-                .hasNext(slice.hasNext())
-                .topics(topics)
-                .build();
     }
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package UMC.news.newsIntelligent.domain.topic.service.query;
 
+import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
+import UMC.news.newsIntelligent.domain.member.service.MemberTopicQueryService;
 import UMC.news.newsIntelligent.domain.news.entity.News;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
 import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
@@ -27,9 +29,12 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
     private final TopicRepository topicRepository;
     private final NewsRepository newsRepository;
+    private final MemberTopicQueryService memberTopicQueryService;
+    private final MemberTopicRepository memberTopicRepository;
+
 
     @Override
-    public TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size) {
+    public TopicResponseDTO.TopicPreviewListResDTO searchTopics(String keyword, Long cursor, int size, Long memberId) {
         cursor = normalizeCursor(cursor);
         size = normalizeSize(size);
 
@@ -37,7 +42,9 @@ public class TopicQueryServiceImpl implements TopicQueryService {
         Slice<Topic> topicSlice = topicRepository.findByKeywordAndCursor(keyword, cursor, pageable);
 
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(topicSlice);
-        return mapSliceToPreviewListDTO(topicSlice, srcMap);
+        Map<Long, Boolean> subMap = memberTopicQueryService.buildSubscribedMap(memberId, topicSlice);
+
+        return mapSliceToPreviewListDTO(topicSlice, srcMap, subMap);
     }
 
     private Long normalizeCursor(Long cursor) {
@@ -50,7 +57,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
     }
 
     @Override
-    public TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size) {
+    public TopicResponseDTO.TopicPreviewListResDTO getTopicList(Long cursor, int size, Long memberId) {
         size = normalizeSize(size);
 
         Pageable pageable = PageRequest.of(0, size);
@@ -68,11 +75,13 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
         Slice<Topic> slice = topicRepository.findByCursorOrderBySummaryTimeDesc(cursorTime, cursorId, pageable);
         Map<Long, TopicResponseDTO.ImageSource> srcMap = buildImageSourceMapFromSlice(slice);
-        return mapSliceToPreviewListDTO(slice, srcMap);
+        Map<Long, Boolean> subMap = memberTopicQueryService.buildSubscribedMap(memberId, slice);
+
+        return mapSliceToPreviewListDTO(slice, srcMap, subMap);
     }
 
     @Override
-    public TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId) {
+    public TopicResponseDTO.TopicPreviewResDTO getTopicById(Long topicId, Long memberId) {
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
 
@@ -84,17 +93,24 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                 .title(source.getTitle())
                 .build();
 
-        return new TopicResponseDTO.TopicPreviewResDTO(
-                topic.getId(),
-                topic.getTopicName(),
-                topic.getAiSummary(),
-                topic.getSummaryTime(),
-                topic.getImageUrl(),
-                imageSource
-        );
+        boolean isSub = false; // 기본 false (비로그인)
+        if (memberId != null) {
+            isSub = memberTopicRepository
+                    .existsByMemberIdAndTopicIdAndIsSubscribeTrue(memberId, topicId); // ✅ 단건 체크
+        }
+
+        return TopicResponseDTO.TopicPreviewResDTO.builder()
+                .id(topic.getId())
+                .topicName(topic.getTopicName())
+                .aiSummary(topic.getAiSummary())
+                .summaryTime(topic.getSummaryTime())
+                .imageUrl(topic.getImageUrl())
+                .imageSource(imageSource)
+                .isSub(isSub)
+                .build();
     }
 
-    // // 해당 페이지 topicId 수집 후 각 토픽의 출처 기사 한 번에 조회 -> Map
+    // 해당 페이지 topicId 수집 후 각 토픽의 출처 기사 한 번에 조회 -> Map
     private Map<Long, TopicResponseDTO.ImageSource> buildImageSourceMapFromSlice(Slice<Topic> slice) {
         List<Long> topicIds = slice.getContent().stream()
                 .map(Topic::getId)
@@ -118,10 +134,11 @@ public class TopicQueryServiceImpl implements TopicQueryService {
 
     private TopicResponseDTO.TopicPreviewListResDTO mapSliceToPreviewListDTO(
             Slice<Topic> slice,
-            Map<Long, TopicResponseDTO.ImageSource> srcMap
+            Map<Long, TopicResponseDTO.ImageSource> srcMap,
+            Map<Long, Boolean> subMap
     ) {
         List<TopicResponseDTO.TopicPreviewResDTO> topics =
-                TopicConverter.toPreviewResDTOList(slice.getContent(), srcMap);
+                TopicConverter.toPreviewResDTOList(slice.getContent(), srcMap, subMap);
 
         Long nextCursor = (slice.hasNext() && !topics.isEmpty())
                 ? topics.get(topics.size() - 1).id()


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #99

## 💻 작업 내용

- 토픽 조회 시 구독 여부 함께 반환하도록 수정
    - [x] 토픽 목록(홈화면) 조회
    - [x] 토픽 검색 결과 조회
    - [x] 토픽 상세 페이지 조회
    - [x] 최신 수정 보도 조회
    - [x] 구독 토픽 리스트 조회
    - [x] 읽은 토픽 목록 리스트 조회
    - [x] 읽은 토픽 목록 내 조회
- 테스트 완료
## ❗️Remark
- 로그인 없이도 사용 가능한 기능의 경우
    - 로그인 안 한 경우 -> 무조건 구독여부 false
    - 로그인 한 경우 -> 로그인된 사용자의 구독 여부 반환
