### PR TITLE
Refactor: 홈 화면과 구독 화면 imageSource에 newsLink 추가 

### DIFF
--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -4,11 +4,9 @@ import UMC.news.newsIntelligent.domain.member.converter.MemberTopicConverter;
 import UMC.news.newsIntelligent.domain.member.dto.MemberTopicResponseDTO;
 import UMC.news.newsIntelligent.domain.member.entity.MemberTopic;
 import UMC.news.newsIntelligent.domain.member.repository.MemberTopicRepository;
-import UMC.news.newsIntelligent.domain.member.support.TopicQueryUtils;
 import UMC.news.newsIntelligent.domain.news.repository.NewsRepository;
 import UMC.news.newsIntelligent.domain.news.repository.projection.OldestPerTopicProjection;
 import UMC.news.newsIntelligent.domain.topic.dto.TopicResponseDTO;
-import UMC.news.newsIntelligent.domain.topic.entity.Topic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -87,6 +85,7 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
                         p -> TopicResponseDTO.ImageSource.builder()
                                 .press(p.getPress())
                                 .title(p.getTitle())
+                                .url(p.getNewsLink())
                                 .build(),
                         (a, b) -> a
                 )

--- a/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/member/service/MemberTopicQueryServiceImpl.java
@@ -85,7 +85,7 @@ public class MemberTopicQueryServiceImpl implements MemberTopicQueryService {
                         p -> TopicResponseDTO.ImageSource.builder()
                                 .press(p.getPress())
                                 .title(p.getTitle())
-                                .url(p.getNewsLink())
+                                .newsLink(p.getNewsLink())
                                 .build(),
                         (a, b) -> a
                 )

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
@@ -56,21 +56,24 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     List<News> findTop3QualifiedNewsByTopicId(@Param("topicId") Long topicId);
 
     @Query("""
-SELECT n.topic.id AS topicId, n.press AS press, n.title AS title
-FROM News n
-WHERE n.topic.id IN :topicIds
-  AND n.publishDate = (
-      SELECT MIN(n2.publishDate)
-      FROM News n2
-      WHERE n2.topic.id = n.topic.id
-  )
-  AND n.id = (
-      SELECT MAX(n3.id)
-      FROM News n3
-      WHERE n3.topic.id = n.topic.id
-        AND n3.publishDate = n.publishDate
-  )
-""")
+    SELECT n.topic.id AS topicId, 
+            n.press AS press,
+            n.title AS title,
+            n.newsLink AS newsLink 
+    FROM News n
+    WHERE n.topic.id IN :topicIds
+      AND n.publishDate = (
+          SELECT MIN(n2.publishDate)
+          FROM News n2
+          WHERE n2.topic.id = n.topic.id
+      )
+      AND n.id = (
+          SELECT MAX(n3.id)
+          FROM News n3
+          WHERE n3.topic.id = n.topic.id
+            AND n3.publishDate = n.publishDate
+      )
+    """)
     List<OldestPerTopicProjection> findOldestPerTopic(java.util.Collection<Long> topicIds);
 
     // is_new = true AND is_third = false 인 기사 중

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/NewsRepository.java
@@ -106,21 +106,5 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     // 특정 토픽 내에서 가장 오래된 publishDate, id가 가장 큰 기사
     Optional<News> findFirstByTopicIdOrderByPublishDateAscIdDesc(Long topicId);
 }
-//    @Query(value = """
-//    SELECT n.*
-//    FROM news n
-//    JOIN (
-//        SELECT topic_id
-//        FROM news
-//        WHERE is_new = 1
-//          AND is_third = 0
-//        GROUP BY topic_id
-//        HAVING COUNT(*) >= 3
-//        ORDER BY COUNT(*) DESC, MAX(id) DESC   -- 동률이면 id 큰 토픽 우선
-//        LIMIT 1
-//    ) t ON t.topic_id = n.topic_id
-//    WHERE n.is_new = 1
-//      AND n.is_third = 0
-//    """, nativeQuery = true)
-//    List<News> findArticlesOfTopTopicByCount();
+
 

--- a/src/main/java/UMC/news/newsIntelligent/domain/news/repository/projection/OldestPerTopicProjection.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/news/repository/projection/OldestPerTopicProjection.java
@@ -4,4 +4,5 @@ public interface OldestPerTopicProjection {
     Long getTopicId();
     String getPress();
     String getTitle();
+    String getNewsLink();
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/dto/TopicResponseDTO.java
@@ -30,6 +30,7 @@ public class TopicResponseDTO {
     @Builder
     public record ImageSource(
             String press,
-            String title
+            String title,
+            String newsLink
     ) {}
 }

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -125,7 +125,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                         p -> TopicResponseDTO.ImageSource.builder()
                                 .press(p.getPress())
                                 .title(p.getTitle())
-                                .url(p.getNewsLink())
+                                .newsLink(p.getNewsLink())
                                 .build(),
                         (a, b) -> a
                 )

--- a/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
+++ b/src/main/java/UMC/news/newsIntelligent/domain/topic/service/query/TopicQueryServiceImpl.java
@@ -125,6 +125,7 @@ public class TopicQueryServiceImpl implements TopicQueryService {
                         p -> TopicResponseDTO.ImageSource.builder()
                                 .press(p.getPress())
                                 .title(p.getTitle())
+                                .url(p.getNewsLink())
                                 .build(),
                         (a, b) -> a
                 )


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #103 

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용
- 홈화면 조회 시 imageSource에 newsLink를 추가
- 마이페이지 구독 화면 imageSource에 newsLink를 추가
- NewsRepository 불필요한 주석 제거 
<!-- 무엇을 왜 수정했는지 설명하면 리뷰어에게 도움이 됩니다!-->

## 🖼️ 관련 스크린샷 (선택)
<img width="1197" height="372" alt="image" src="https://github.com/user-attachments/assets/169ca5e7-023f-44e2-9a51-23f5720f56b4" />


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
이전 코드와 크게 달라진 것은 없습니다!!! 
